### PR TITLE
Bugfix 430 develop now time

### DIFF
--- a/internal_tests/pytests/met_util/test_met_util.py
+++ b/internal_tests/pytests/met_util/test_met_util.py
@@ -646,3 +646,28 @@ def test_get_process_list(input_list, expected_list):
     conf.set('config', 'PROCESS_LIST', input_list)
     output_list = util.get_process_list(conf)
     assert(output_list == expected_list)
+
+@pytest.mark.parametrize(
+    'time_from_conf, fmt, is_datetime', [
+        ('', '%Y', False),
+        ('a', '%Y', False),
+        ('1987', '%Y', True),
+        ('1987', '%Y%m', False),
+        ('198702', '%Y%m', True),
+        ('198702', '%Y%m%d', False),
+        ('19870201', '%Y%m%d', True),
+        ('19870201', '%Y%m%d%H', False),
+        ('{now?fmt=%Y%m%d}', '%Y%m%d', True),
+        ('{now?fmt=%Y%m%d}', '%Y%m%d%H', True),
+        ('{now?fmt=%Y%m%d}00', '%Y%m%d%H', True),
+        ('{today}', '%Y%m%d', True),
+        ('{today}', '%Y%m%d%H', True),
+    ]
+)
+
+def test_get_time_obj(time_from_conf, fmt, is_datetime):
+    clock_time = datetime.datetime(2019, 12, 31, 15, 30)
+
+    time_obj = util.get_time_obj(time_from_conf, fmt, clock_time)
+
+    assert(isinstance(time_obj, datetime.datetime) == is_datetime)

--- a/ush/met_util.py
+++ b/ush/met_util.py
@@ -760,14 +760,32 @@ def is_loop_by_init(config):
 
     exit(1)
 
-
 def get_time_obj(time_from_conf, fmt, clock_time, logger=None):
-    """!Substitute today or now into [INIT/VALID]_[BEG/END] if used"""
-    sts = StringSub(logger, time_from_conf,
-                    now=clock_time,
-                    today=clock_time.strftime('%Y%m%d'))
-    time_str = sts.do_string_sub()
-    return datetime.datetime.strptime(time_str, fmt)
+    """!Substitute today or now into [INIT/VALID]_[BEG/END] if used
+        Args:
+            @param time_from_conf value from [INIT/VALID]_[BEG/END] that
+                   may include now or today tags
+            @param fmt format of time_from_conf, i.e. %Y%m%d
+            @param clock_time datetime object for time when execution started
+            @param logger log object to write error messages - None if not provided
+            @returns datetime object if successful, None if not
+    """
+    time_str = StringSub(logger, time_from_conf,
+                         now=clock_time,
+                         today=clock_time.strftime('%Y%m%d')).do_string_sub()
+    try:
+        time_t = datetime.datetime.strptime(time_str, fmt)
+    except ValueError:
+        error_message = (f"[INIT/VALID]_TIME_FMT ({fmt}) does not match "
+                         f"[INIT/VALID]_[BEG/END] ({time_str})")
+        if logger:
+            logger.error(error_message)
+        else:
+            print(f"ERROR: {error_message}")
+
+        return None
+
+    return time_t
 
 def get_start_end_interval_times(config):
     clock_time_obj = datetime.datetime.strptime(config.getstr('config', 'CLOCK_TIME'),
@@ -784,23 +802,24 @@ def get_start_end_interval_times(config):
         end_t = config.getraw('config', 'VALID_END')
         time_interval = time_util.get_relativedelta(config.getstr('config', 'VALID_INCREMENT'))
 
-    # verify that *_TIME_FMT matches *_BEG and *_END
-    time_format_len = len(datetime.datetime.now().strftime(time_format))
-    if len(start_t) != time_format_len:
-        config.logger.error(f"[INIT/VALID]_TIME_FMT {time_format} does not match [INIT/VALID]_BEG {start_t}.")
-        return None
-
-    if len(end_t) != time_format_len:
-        config.logger.error(f"[INIT/VALID]_TIME_FMT ({time_format}) does not match [INIT/VALID]_END ({end_t}).")
-        return None
-
     start_time = get_time_obj(start_t, time_format,
                              clock_time_obj, config.logger)
+    if not start_time:
+        config.logger.error("Could not format start time")
+        return None
+
     end_time = get_time_obj(end_t, time_format,
                             clock_time_obj, config.logger)
+    if not end_time:
+        config.logger.error("Could not format end time")
+        return None
 
     if start_time + time_interval < start_time + datetime.timedelta(seconds=60):
         config.logger.error("[INIT/VALID]_INCREMENT must be greater than or equal to 60 seconds")
+        return None
+
+    if start_time > end_time:
+        config.logger.error("Start time must come before end time")
         return None
 
     return start_time, end_time, time_interval

--- a/ush/string_template_substitution.py
+++ b/ush/string_template_substitution.py
@@ -89,17 +89,6 @@ def get_tags(template):
         i += 1
     return tags
 
-def get_seconds_from_template(split_item):
-    """!Get seconds value from tag that contains a shift or truncate item"""
-    shift_split_string = \
-        split_item.split(FORMATTING_VALUE_DELIMITER)
-
-    if len(shift_split_string) != 2:
-        return
-
-    seconds = shift_split_string[1]
-    return int(time_util.get_seconds_from_string(seconds, default_unit='S'))
-
 def format_one_time_item(item, time_str, unit):
     """!Determine precision of time offset value and format
         Args:
@@ -267,6 +256,26 @@ class StringSub(object):
             for key, value in kwargs.items():
                 setattr(self, key, value)
 
+    def get_seconds_from_template(self, split_item):
+        """!Get seconds value from tag that contains a shift or truncate item
+             Args:
+                 @param split_item key/value from string sub tag to evalute, i.e. shift=-1H
+                 @returns integer number of seconds that correspond to the item, i.e. -3600
+         """
+        shift_split_string = split_item.split(FORMATTING_VALUE_DELIMITER)
+
+        if len(shift_split_string) != 2:
+            return
+
+        valid_time = self.kwargs.get('valid',
+                                     self.kwargs.get('now',
+                                                     None))
+
+        seconds = shift_split_string[1]
+        return int(time_util.get_seconds_from_string(seconds,
+                                                     default_unit='S',
+                                                     valid_time=valid_time))
+
     def round_time_down(self, obj):
         """!If template value needs to be truncated, round the value down
             to the given truncate interval"""
@@ -433,12 +442,12 @@ class StringSub(object):
             # if shift is set, get that value before handling formatting
             for split_item in split_string:
                 if split_item.startswith(SHIFT_STRING):
-                    self.shift_seconds = get_seconds_from_template(split_item)
+                    self.shift_seconds = self.get_seconds_from_template(split_item)
 
             # if truncate is set, get that value before handling formatting
             for split_item in split_string:
                 if split_item.startswith(TRUNCATE_STRING):
-                    self.truncate_seconds = get_seconds_from_template(split_item)
+                    self.truncate_seconds = self.get_seconds_from_template(split_item)
 
             # format times appropriately and add to replacement_dict
             formatted = False

--- a/ush/time_util.py
+++ b/ush/time_util.py
@@ -69,6 +69,7 @@ def get_relativedelta(value, default_unit='S'):
             return relativedelta(years=time_value)
 
         # unsupported time unit specified, return None
+        return None
 
 def get_seconds_from_string(value, default_unit='S', valid_time=None):
     """!Convert string of time (optionally ending with time letter, i.e. HMSyMD to seconds


### PR DESCRIPTION
The same changes were made to develop as the previous pull request.

The following file can be used to test that the changes work. Running on develop should result in an error, but running on this branch should work correctly.

kiowa:/d1/projects/METplus/METplus_test_environments/NowTimeFormat/Example_now.conf