### PR TITLE
Feature 404 begin end incr enhance

### DIFF
--- a/docs/Users_Guide/quicksearch.rst
+++ b/docs/Users_Guide/quicksearch.rst
@@ -55,6 +55,7 @@ Use Cases by METplus Feature:
 | `Feature Relative  <https://ncar.github.io/METplus/search.html?q=FeatureRelativeUseCase&check_keywords=yes&area=default>`_
 | `GempakToCF <https://ncar.github.io/METplus/search.html?q=GempakToCFToolUseCase&check_keywords=yes&area=default>`_
 | `Looping by Month or Year  <https://ncar.github.io/METplus/search.html?q=LoopByMonthFeatureUseCase&check_keywords=yes&area=default>`_
+| `List Expansion (using begin_end_incr syntax)  <https://ncar.github.io/METplus/search.html?q=ListExpansionFeatureUseCase&check_keywords=yes&area=default>`_
 | `Masking for Regions of Interest <https://ncar.github.io/METplus/search.html?q=MaskingFeatureUseCase&check_keywords=yes&area=default>`_
 | `MET_PYTHON_EXE Environment Variable  <https://ncar.github.io/METplus/search.html?q=MET_PYTHON_EXEUseCase&check_keywords=yes&area=default>`_
 | `Multiple Conf File Use <https://ncar.github.io/METplus/search.html?q=MultiConfUseCase&check_keywords=yes&area=default>`_

--- a/internal_tests/pytests/met_util/test_met_util.py
+++ b/internal_tests/pytests/met_util/test_met_util.py
@@ -445,29 +445,63 @@ def test_get_lead_sequence_lead_list(key, value):
     lead_seq = value
     assert(hour_seq == lead_seq)
 
-
-
 @pytest.mark.parametrize(
-    'key, value', [
-        ('begin_end_incr(3,12,3)',  [ '3', '6', '9', '12']),
-        ('1,2,3,4',  [ '1', '2', '3', '4']),
-        (' 1,2,3,4',  [ '1', '2', '3', '4']),
-        ('1,2,3,4 ',  [ '1', '2', '3', '4']),
-        (' 1,2,3,4 ',  [ '1', '2', '3', '4']),
-        ('1, 2,3,4',  [ '1', '2', '3', '4']),
-        ('1,2, 3, 4',  [ '1', '2', '3', '4']),
-        ('begin_end_incr( 3,12 , 3)',  [ '3', '6', '9', '12']),
-        ('begin_end_incr(0,10,2)',  [ '0', '2', '4', '6', '8', '10']),
-        ('begin_end_incr(10,0,-2)',  [ '10', '8', '6', '4', '2', '0']),
-        ('begin_end_incr(2,2,20)',  [ '2' ]),
-        ('begin_end_incr(0,2,1), begin_end_incr(3,9,3)', ['0','1','2','3','6','9']),
-        ('mem_begin_end_incr(0,2,1), mem_begin_end_incr(3,9,3)', ['mem_0','mem_1','mem_2','mem_3','mem_6','mem_9']),
+    'list_string, output_list', [
+        ('begin_end_incr(3,12,3)',
+         ['3', '6', '9', '12']),
+
+        ('1,2,3,4',
+         ['1', '2', '3', '4']),
+
+        (' 1,2,3,4',
+         ['1', '2', '3', '4']),
+
+        ('1,2,3,4 ',
+         ['1', '2', '3', '4']),
+
+        (' 1,2,3,4 ',
+         ['1', '2', '3', '4']),
+
+        ('1, 2,3,4',
+         ['1', '2', '3', '4']),
+
+        ('1,2, 3, 4',
+         ['1', '2', '3', '4']),
+
+        ('begin_end_incr( 3,12 , 3)',
+         ['3', '6', '9', '12']),
+
+        ('begin_end_incr(0,10,2)',
+         ['0', '2', '4', '6', '8', '10']),
+
+        ('begin_end_incr(10,0,-2)',
+         ['10', '8', '6', '4', '2', '0']),
+
+        ('begin_end_incr(2,2,20)',
+         ['2']),
+
+        ('begin_end_incr(0,2,1), begin_end_incr(3,9,3)',
+         ['0','1','2','3','6','9']),
+
+        ('mem_begin_end_incr(0,2,1), mem_begin_end_incr(3,9,3)',
+         ['mem_0','mem_1','mem_2','mem_3','mem_6','mem_9']),
+
+        ('mem_begin_end_incr(0,2,1,3), mem_begin_end_incr(3,12,3,3)',
+         ['mem_000', 'mem_001', 'mem_002', 'mem_003', 'mem_006', 'mem_009', 'mem_012']),
+
         ('begin_end_incr(0,10,2)H, 12',  [ '0H', '2H', '4H', '6H', '8H', '10H', '12']),
+
         ('begin_end_incr(0,10800,3600)S, 4H',  [ '0S', '3600S', '7200S', '10800S', '4H']),
+
+        ('data.{init?fmt=%Y%m%d%H?shift=begin_end_incr(0, 3, 3)H}.ext',
+         ['data.{init?fmt=%Y%m%d%H?shift=0H}.ext',
+          'data.{init?fmt=%Y%m%d%H?shift=3H}.ext',
+          ]),
+
     ]
 )
-def test_getlist_begin_end_incr(key, value):
-    assert(util.getlist(key) == value)
+def test_getlist_begin_end_incr(list_string, output_list):
+    assert(util.getlist(list_string) == output_list)
 
 # @pytest.mark.parametrize(
 #     'key, value', [

--- a/parm/use_cases/met_tool_wrapper/SeriesAnalysis/SeriesAnalysis.conf
+++ b/parm/use_cases/met_tool_wrapper/SeriesAnalysis/SeriesAnalysis.conf
@@ -127,14 +127,20 @@ SERIES_ANALYSIS_OUTPUT_DIR = {OUTPUT_BASE}/met_tool_wrapper/SeriesAnalysis
 [filename_templates]
 
 # Template to look for forecast input to SeriesAnalysis relative to FCST_SERIES_ANALYSIS_INPUT_DIR
-FCST_SERIES_ANALYSIS_INPUT_TEMPLATE = {init?fmt=%Y%m%d%H}/wrfprs_ruc13_{lead?fmt=%HH}.tm00_G212,
-                                      {init?fmt=%Y%m%d%H}/wrfprs_ruc13_{lead?fmt=%HH?shift=-3H}.tm00_G212,
-                                      {init?fmt=%Y%m%d%H}/wrfprs_ruc13_{lead?fmt=%HH?shift=-6H}.tm00_G212
+# The following template uses begin_end_incr() syntax to generate the following list:
+#  {init?fmt=%Y%m%d%H}/wrfprs_ruc13_{lead?fmt=%HH}.tm00_G212,
+#  {init?fmt=%Y%m%d%H}/wrfprs_ruc13_{lead?fmt=%HH?shift=-3H}.tm00_G212,
+#  {init?fmt=%Y%m%d%H}/wrfprs_ruc13_{lead?fmt=%HH?shift=-6H}.tm00_G212
+
+FCST_SERIES_ANALYSIS_INPUT_TEMPLATE = {init?fmt=%Y%m%d%H}/wrfprs_ruc13_{lead?fmt=%HH?shift=begin_end_incr(0,-6,-3)H}.tm00_G212
 
 # Template to look for observation input to SeriesAnalysis relative to OBS_SERIES_ANALYSIS_INPUT_DIR
-OBS_SERIES_ANALYSIS_INPUT_TEMPLATE = ST2ml{valid?fmt=%Y%m%d%H}_A03h.nc,
-                                     ST2ml{valid?fmt=%Y%m%d%H?shift=-3H}_A03h.nc,
-                                     ST2ml{valid?fmt=%Y%m%d%H?shift=-6H}_A03h.nc
+# The following template uses begin_end_incr() syntax to generate the following list:
+#   ST2ml{valid?fmt=%Y%m%d%H}_A03h.nc,
+#   ST2ml{valid?fmt=%Y%m%d%H?shift=-3H}_A03h.nc,
+#   ST2ml{valid?fmt=%Y%m%d%H?shift=-6H}_A03h.nc
+
+OBS_SERIES_ANALYSIS_INPUT_TEMPLATE = ST2ml{valid?fmt=%Y%m%d%H?shift=begin_end_incr(0,-6,-3)H}_A03h.nc
 
 # Optional subdirectories relative to SERIES_ANALYSIS_OUTPUT_DIR to write output from SeriesAnalysis
 SERIES_ANALYSIS_OUTPUT_TEMPLATE = {init?fmt=%Y%m%d%H}_sa.nc

--- a/parm/use_cases/met_tool_wrapper/SeriesAnalysis/SeriesAnalysis.py
+++ b/parm/use_cases/met_tool_wrapper/SeriesAnalysis/SeriesAnalysis.py
@@ -122,5 +122,6 @@ SeriesAnalysis.conf
 # .. note::
 #  `SeriesAnalysisUseCase <https://ncar.github.io/METplus/search.html?q=SeriesAnalysisUseCase&check_keywords=yes&area=default>`_
 #  `DiagnosticsUseCase <https://ncar.github.io/METplus/search.html?q=DiagnosticsUseCase&check_keywords=yes&area=default>`_
+#  `ListExpansionFeatureUseCase <https://ncar.github.io/METplus/search.html?q=ListExpansionFeatureUseCase&check_keywords=yes&area=default>`_
 #
 # sphinx_gallery_thumbnail_path = '_static/met_tool_wrapper-SeriesAnalysis.png'

--- a/parm/use_cases/model_applications/precipitation/EnsembleStat_fcstHRRRE_FcstOnly_NetCDF.conf
+++ b/parm/use_cases/model_applications/precipitation/EnsembleStat_fcstHRRRE_FcstOnly_NetCDF.conf
@@ -78,9 +78,10 @@ ENSEMBLE_STAT_OUTPUT_DIR = {OUTPUT_BASE}/model_applications/precipitation/Ensemb
 
 [filename_templates]
 
-FCST_ENSEMBLE_STAT_INPUT_TEMPLATE = hrrre01_{init?fmt=%Y%m%d%H}f{lead?fmt=%HHH}_A03.nc,
-    hrrre02_{init?fmt=%Y%m%d%H}f{lead?fmt=%HHH}_A03.nc,
-    hrrre03_{init?fmt=%Y%m%d%H}f{lead?fmt=%HHH}_A03.nc
-
+# the following template uses begin_end_incr() notation that expands to:
+#  hrrre01_{init?fmt=%Y%m%d%H}f{lead?fmt=%HHH}_A03.nc,
+#  hrrre02_{init?fmt=%Y%m%d%H}f{lead?fmt=%HHH}_A03.nc,
+#  hrrre03_{init?fmt=%Y%m%d%H}f{lead?fmt=%HHH}_A03.nc
+FCST_ENSEMBLE_STAT_INPUT_TEMPLATE = hrrrebegin_end_incr(1,3,1,2)_{init?fmt=%Y%m%d%H}f{lead?fmt=%HHH}_A03.nc
 
 ENSEMBLE_STAT_OUTPUT_TEMPLATE = {init?fmt=%Y%m%d%H%M}

--- a/parm/use_cases/model_applications/precipitation/EnsembleStat_fcstHRRRE_FcstOnly_NetCDF.py
+++ b/parm/use_cases/model_applications/precipitation/EnsembleStat_fcstHRRRE_FcstOnly_NetCDF.py
@@ -151,8 +151,6 @@ _FcstOnly_NetCDF.conf
 # Keywords
 # --------
 #
-# sphinx_gallery_thumbnail_path = '_static/precipitation-EnsembleStat_fcstHRRRE_FcstOnly_NetCDF.png'
-#
 # .. note::
 #    `EnsembleStatToolUseCase <https://ncar.github.io/METplus/search.html?q=EnsembleStatToolUseCase&check_keywords=yes&area=default>`_,
 #    `NOAAHWTOrgUseCase  <https://ncar.github.io/METplus/search.html?q=NOAAHWTOrgUseCase&check_keywords=yes&area=default>`_,
@@ -161,3 +159,6 @@ _FcstOnly_NetCDF.conf
 #    `EnsembleAppUseCase <https://ncar.github.io/METplus/search.html?q=EnsembleAppUseCase&check_keywords=yes&area=default>`_,
 #    `ConvectionAllowingModelsAppUseCase <https://ncar.github.io/METplus/search.html?q=ConvectionAllowingModelsAppUseCase&check_keywords=yes&area=default>`_,
 #    `ProbabilityGenerationAppUseCase <https://ncar.github.io/METplus/search.html?q=ProbabilityGenerationAppUseCase&check_keywords=yes&area=default>`_,
+#    `ListExpansionFeatureUseCase <https://ncar.github.io/METplus/search.html?q=ListExpansionFeatureUseCase&check_keywords=yes&area=default>`_
+
+# sphinx_gallery_thumbnail_path = '_static/precipitation-EnsembleStat_fcstHRRRE_FcstOnly_NetCDF.png'

--- a/ush/command_builder.py
+++ b/ush/command_builder.py
@@ -426,7 +426,7 @@ class CommandBuilder:
 
         # check if there is a list of files provided in the template
         # process each template in the list (or single template)
-        template_list = [template.strip() for template in input_template.split(',')]
+        template_list = util.getlist(input_template)
 
         # return None if a list is provided for a wrapper that doesn't allow
         # multiple files to be processed
@@ -776,7 +776,7 @@ class CommandBuilder:
             return None
 
         except ValueError:
-            self.log_error(f"[{section}] {name} must be an {typeobj}. Value is {value}")
+            self.log_error(f"[{section}] {name} (value: {value}) must be an {typeobj.__class__.__name__}")
             self.isOK = False
             return None
 

--- a/ush/met_util.py
+++ b/ush/met_util.py
@@ -1717,25 +1717,72 @@ def get_dirs(base_dir):
 
     return dir_list
 
+def handle_begin_end_incr(list_str):
+    """!Check for instances of begin_end_incr() in the input string and evaluate as needed
+        Args:
+            @param list_str string that contains a comma separated list
+            @returns string that has list expanded"""
+
+    matches = begin_end_incr_findall(list_str)
+
+    for match in matches:
+        item_list = begin_end_incr_evaluate(match)
+        if item_list:
+            list_str = list_str.replace(match, ','.join(item_list))
+
+    return list_str
+
+def begin_end_incr_findall(list_str):
+    """!Find all instances of begin_end_incr in list string
+        Args:
+            @param list_str string that contains a comma separated list
+            @returns list of strings that have begin_end_incr() characters"""
+    # remove space around commas (again to make sure)
+    # this makes the regex slightly easier because we don't have to include
+    # as many \s* instances in the regex string
+    list_str = re.sub(r'\s*,\s*', ',', list_str)
+
+    # find begin_end_incr and any text before and after that are not a comma
+    # [^,\s]* evaluates to any character that is not a comma or space
+    return re.findall(r"([^,]*begin_end_incr\(\s*-?\d*,-?\d*,-*\d*,?\d*\s*\)[^,]*)",
+                      list_str)
+
 def begin_end_incr_evaluate(item):
-    match = re.match(r'^(.*)begin_end_incr\(\s*(-*\d*),(-*\d*),(-*\d*)\s*\)(.*)$',
+    """!Expand begin_end_incr() items into a list of values
+        Args:
+            @param item string containing begin_end_incr() tag with
+            possible text before and after
+            @returns list of items expanded from begin_end_incr
+    """
+    match = re.match(r"^(.*)begin_end_incr\(\s*(-*\d*),(-*\d*),(-*\d*),?(\d*)\s*\)(.*)$",
                      item)
     if match:
-        before = match.group(1)
-        after = match.group(5)
+        before = match.group(1).strip()
+        after = match.group(6).strip()
         start = int(match.group(2))
         end = int(match.group(3))
         step = int(match.group(4))
+        precision = match.group(5).strip()
+
         if start <= end:
             int_list = range(start, end+1, step)
         else:
             int_list = range(start, end-1, step)
 
-        return [f"{before}{str(out_str)}{after}" for out_str in int_list]
+        out_list = []
+        for int_values in int_list:
+            out_str = str(int_values)
+
+            if precision:
+                out_str = out_str.zfill(int(precision))
+
+            out_list.append(f"{before}{out_str}{after}")
+
+        return out_list
 
     return None
 
-def getlist(list_str, logger=None):
+def getlist(list_str):
     """! Returns a list of string elements from a comma
          separated string of values.
          This function MUST also return an empty list [] if s is '' empty.
@@ -1748,6 +1795,7 @@ def getlist(list_str, logger=None):
          a conf file returns '' an empty string.
 
         @param list_str the string being converted to a list.
+        @returns list of strings formatted properly and expanded as needed
     """
     # FIRST remove surrounding comma, and spaces, form the string.
     list_str = list_str.strip().strip(',').strip()
@@ -1755,13 +1803,7 @@ def getlist(list_str, logger=None):
     # remove space around commas
     list_str = re.sub(r'\s*,\s*', ',', list_str)
 
-    # find begin_end_incr and any text before and after that are not a comma
-    matches = re.findall(r'([^,]*begin_end_incr\(\s*-*\d*,-*\d*,-*\d*\s*\)[^,]*)',
-                       list_str)
-    for match in matches:
-        item_list = begin_end_incr_evaluate(match)
-        if item_list:
-            list_str = list_str.replace(match, ','.join(item_list))
+    list_str = handle_begin_end_incr(list_str)
 
     # use csv reader to divide comma list while preserving strings with comma
     # convert the csv reader to a list and get first item (which is the whole list)
@@ -1769,13 +1811,21 @@ def getlist(list_str, logger=None):
     return item_list
 
 def getlistfloat(list_str):
-    """!Get list and convert all values to float"""
+    """!Get list and convert all values to float
+        Args:
+            @param list_str the string being converted to a list.
+            @returns list of floats
+    """
     list_str = getlist(list_str)
     list_str = [float(i) for i in list_str]
     return list_str
 
 def getlistint(list_str):
-    """!Get list and convert all values to int"""
+    """!Get list and convert all values to int
+            Args:
+            @param list_str the string being converted to a list.
+            @returns list of ints
+    """
     list_str = getlist(list_str)
     list_str = [int(i) for i in list_str]
     return list_str


### PR DESCRIPTION
Enhanced support for begin_end_incr() syntax to be more flexible, added support for a 4th argument that sets the zero precision. Anywhere in METplus that uses met_util.getlist to parse a list now supports this syntax. I modified the CommandBuilder.find_data method to use getlist so this is now also supported in filename templates that can take a list.

I updated 2 existing use cases that previously spelled out a list to use this functionality. I also added a new Quick Search item (ListExpansionFeatureUseCase) and added those keywords to the use cases.

New pytests exists to test this functionality. You can also test running the two use cases using METplus 3.0 and then again with this branch to verify that the changes to the code/config file produce the same results.