### PR TITLE
Feature 498 master v3.0 docker

### DIFF
--- a/internal_tests/docker/Dockerfile
+++ b/internal_tests/docker/Dockerfile
@@ -62,4 +62,5 @@ RUN yum -y update \
  && yum -y install java-1.8.0-openjdk \
  && python3 -m pip install pytest
 
-
+RUN git clone -b master_v3.0 https://github.com/NCAR/METplus \
+&& sed -i 's|MET_INSTALL_DIR = /path/to|MET_INSTALL_DIR = /usr/local|g' METplus/parm/metplus_config/metplus_system.conf

--- a/internal_tests/docker/Dockerfile
+++ b/internal_tests/docker/Dockerfile
@@ -1,9 +1,29 @@
-FROM dtcenter/met:master_v9.0
+ARG MET_BRANCH
+
+FROM dtcenter/met:${MET_BRANCH:-develop}
 MAINTAINER George McCabe <mccabe@ucar.edu>
 
 # 
 # This Dockerfile extends the MET image file to run METplus
 #
+
+ARG SOURCE_BRANCH
+
+RUN if [ -z ${SOURCE_BRANCH+x} ]; then \
+      echo "ERROR: SOURCE_BRANCH undefined! Rebuild with \"--build-arg SOURCE_BRANCH={branch name}\""; \
+      exit 1; \
+    else \
+      echo "Build Argument SOURCE_BRANCH=${SOURCE_BRANCH}"; \
+    fi
+
+ARG MET_BRANCH
+
+RUN if [ -z ${MET_BRANCH+x} ]; then \
+      echo "ERROR: MET_BRANCH undefined! Using default (develop) or rebuild with \"--build-arg MET_BRANCH={branch name}\""; \
+      exit 1; \
+    else \
+      echo "Build Argument MET_BRANCH=${MET_BRANCH}"; \
+    fi
 
 #
 # Set working directory
@@ -45,10 +65,6 @@ RUN echo export PATH=$PATH:/metplus/METplus/ush >> /etc/bashrc \
 # && echo export METPLUS_DISABLE_PLOT_WRAPPERS=yes >> /etc/bashrc \
 # && echo setenv METPLUS_DISABLE_PLOT_WRAPPERS yes >> /etc/csh.cshrc
 ENV METPLUS_DISABLE_PLOT_WRAPPERS yes
-#ENV PYTHONPATH /metplus/METplus/ush
-
-#PATH=$PATH:/new/path/bin
-#ENV PATH "$PATH:/metplus/METplus/ush"
 
 #
 # Install required packages: Pandas, Cartopy*
@@ -62,5 +78,15 @@ RUN yum -y update \
  && yum -y install java-1.8.0-openjdk \
  && python3 -m pip install pytest
 
-RUN git clone -b master_v3.0 https://github.com/NCAR/METplus \
-&& sed -i 's|MET_INSTALL_DIR = /path/to|MET_INSTALL_DIR = /usr/local|g' METplus/parm/metplus_config/metplus_system.conf
+
+ARG SOURCE_BRANCH
+
+# if SOURCE_BRANCH is not develop, clone the repository using the branch
+# also replace MET_INSTALL_DIR value in default conf with correct location
+RUN if [ ${SOURCE_BRANCH} != "develop" ]; then \
+      echo "Cloning METplus repository with -b ${SOURCE_BRANCH}"; \
+      git clone https://github.com/NCAR/METplus; \
+      cd METplus; \
+      git checkout ${SOURCE_BRANCH}; \
+      sed -i 's|MET_INSTALL_DIR = /path/to|MET_INSTALL_DIR = /usr/local|g' parm/metplus_config/metplus_system.conf; \
+   fi

--- a/internal_tests/docker/hooks/build
+++ b/internal_tests/docker/hooks/build
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t $IMAGE_NAME --build-arg SOURCE_BRANCH=$SOURCE_BRANCH --build-arg MET_BRANCH=master_v9.0 .


### PR DESCRIPTION
Added build hooks for Dockerfile to specify the MET branch to use.
If source branch is not develop, clone METplus repo, switch to the branch, and replace the value of MET_INSTALL_DIR with /usr/local.