### PR TITLE
feature 538 StatAnalysis bad wildcard crash 

### DIFF
--- a/internal_tests/pytests/stat_analysis/test_stat_analysis_wrapper.py
+++ b/internal_tests/pytests/stat_analysis/test_stat_analysis_wrapper.py
@@ -625,6 +625,12 @@ def test_get_lookin_dir():
     test_lookin_dir = st.get_lookin_dir(dir_path, lists_to_loop,
                                         lists_to_group, config_dict)
     assert(expected_lookin_dir == test_lookin_dir)
+    # Test 3 - no matches for lookin dir wildcard
+    expected_lookin_dir = ''
+    dir_path = '../../data/fake/*nothingmatches*'
+    test_lookin_dir = st.get_lookin_dir(dir_path, lists_to_loop,
+                                        lists_to_group, config_dict)
+    assert(expected_lookin_dir == test_lookin_dir)
 
 def test_format_valid_init():
     # Independently test the formatting 

--- a/metplus/wrappers/stat_analysis_wrapper.py
+++ b/metplus/wrappers/stat_analysis_wrapper.py
@@ -1035,6 +1035,7 @@ class StatAnalysisWrapper(CommandBuilder):
         if '*' in dir_path_filled:
             self.logger.debug(f"Expanding wildcard path: {dir_path_filled}")
             dir_path_filled_all = ' '.join(sorted(glob.glob(dir_path_filled)))
+            self.logger.warning(f"Wildcard expansion found no matches")
         else:
             dir_path_filled_all = dir_path_filled
         lookin_dir = dir_path_filled_all

--- a/metplus/wrappers/stat_analysis_wrapper.py
+++ b/metplus/wrappers/stat_analysis_wrapper.py
@@ -14,7 +14,7 @@ import logging
 import os
 import copy
 import re
-import subprocess
+import glob
 import datetime
 import itertools
 
@@ -1033,13 +1033,8 @@ class StatAnalysisWrapper(CommandBuilder):
         else:
             dir_path_filled = dir_path
         if '*' in dir_path_filled:
-            dir_path_filled_all = str(
-                subprocess.check_output('ls -d '+dir_path_filled, shell=True)
-            )
-            dir_path_filled_all = (
-                dir_path_filled_all[1:].replace("'","").replace('\\n', ' ')
-            )
-            dir_path_filled_all = dir_path_filled_all[:-1]
+            self.logger.debug(f"Expanding wildcard path: {dir_path_filled}")
+            dir_path_filled_all = ' '.join(sorted(glob.glob(dir_path_filled)))
         else:
             dir_path_filled_all = dir_path_filled
         lookin_dir = dir_path_filled_all
@@ -1646,6 +1641,11 @@ class StatAnalysisWrapper(CommandBuilder):
 
         # set lookin dir command line argument
         runtime_settings_dict['LOOKIN_DIR'] = ' '.join(lookin_dirs)
+
+        # error and return None if lookin dir is empty
+        if not runtime_settings_dict['LOOKIN_DIR']:
+            self.log_error("No value found for lookin dir")
+            return None
 
         if not model_list or not obtype_list:
             self.log_error("Could not find model or obtype to process")


### PR DESCRIPTION
Addresses #538 

I changed the call to subprocess calling ls -d <path> to a glob command that expands the wildcard and returns an empty list if no matches are found. I also added a check to error out if no values for lookin_dir were found due to this and added a pytest to make sure.

I created some test output in kiowa under /d1/projects/METplus/METplus_pull_requests/feature_538

Data under output-old (crash) was generated from using METplus 3.0 with this command:

/home/mccabe/METplus-3.0/ush/master_metplus.py -c /d1/projects/METplus/METplus_pull_requests/feature_538/StatAnalysis_test.conf -c /d1/projects/METplus/METplus_pull_requests/feature_538/user-old.conf


Data under output-new (error and continue) was generated from using the feature branch with this command:

/home/mccabe/METplus/ush/master_metplus.py -c /d1/projects/METplus/METplus_pull_requests/feature_538/StatAnalysis_test.conf -c /d1/projects/METplus/METplus_pull_requests/feature_538/user-new.conf