### PR TITLE
feature 532 import errors from plot wrappers

### DIFF
--- a/metplus/wrappers/cyclone_plotter_wrapper.py
+++ b/metplus/wrappers/cyclone_plotter_wrapper.py
@@ -10,14 +10,18 @@ import datetime
 import re
 import sys
 import collections
-# pylint:disable=import-error
-# numpy, matplotlib and mpl_toolkits are not part of the standard Python
-# library
-import matplotlib.pyplot as plt
-import matplotlib.ticker as mticker
-import cartopy.crs as ccrs
-import cartopy.feature as cfeature
-from cartopy.mpl.gridliner import LONGITUDE_FORMATTER, LATITUDE_FORMATTER
+
+# handle if module can't be loaded to run wrapper
+wrapper_cannot_run = False
+try:
+    import matplotlib.pyplot as plt
+    import matplotlib.ticker as mticker
+    import cartopy.crs as ccrs
+    import cartopy.feature as cfeature
+    from cartopy.mpl.gridliner import LONGITUDE_FORMATTER, LATITUDE_FORMATTER
+except ModuleNotFoundError as err_msg:
+    wrapper_cannot_run = True
+
 import produtil.setup
 
 from ..util import met_util as util
@@ -33,6 +37,12 @@ class CyclonePlotterWrapper(CommandBuilder):
 
         # pylint:disable=redefined-outer-name
         super().__init__(config, logger)
+
+        if wrapper_cannot_run:
+            self.log_error("Cannot run CyclonePlotter wrapper due to import errors. "
+                           "matplotlib and cartopy are required to run.")
+            return
+
         self.input_data = self.config.getdir('CYCLONE_PLOTTER_INPUT_DIR')
         self.output_dir = self.config.getdir('CYCLONE_PLOTTER_OUTPUT_DIR')
         self.init_date = self.config.getstr('config', 'CYCLONE_PLOTTER_INIT_DATE')

--- a/metplus/wrappers/make_plots_wrapper.py
+++ b/metplus/wrappers/make_plots_wrapper.py
@@ -20,7 +20,14 @@ import itertools
 
 from ..util import met_util as util
 from . import CommandBuilder
-from ush.plotting_scripts import plot_util
+
+# handle if module can't be loaded to run wrapper
+wrapper_cannot_run = False
+try:
+    from ush.plotting_scripts import plot_util
+except ModuleNotFoundError as err_msg:
+    wrapper_cannot_run = True
+
 
 class MakePlotsWrapper(CommandBuilder):
     """! Wrapper to used to filter make plots from MET data
@@ -64,6 +71,11 @@ class MakePlotsWrapper(CommandBuilder):
         self.app_path = 'python'
         self.app_name = 'make_plots'
         super().__init__(config, logger)
+
+        if wrapper_cannot_run:
+            self.log_error("Cannot run CyclonePlotter wrapper due to import errors. "
+                           "matplotlib and cartopy are required to run.")
+            return
 
     def get_command(self):
 

--- a/metplus/wrappers/stat_analysis_wrapper.py
+++ b/metplus/wrappers/stat_analysis_wrapper.py
@@ -168,13 +168,16 @@ class StatAnalysisWrapper(CommandBuilder):
         self.runMakePlots = 'MakePlots' in self.config.getstr('config', 'PROCESS_LIST')
         if self.runMakePlots:
             # only import MakePlots wrappers if it will be used
-            from .make_plots_wrapper import MakePlotsWrapper
-            self.check_MakePlots_config(c_dict)
+            from .make_plots_wrapper import MakePlotsWrapper, wrapper_cannot_run
+            if wrapper_cannot_run:
+                self.log_error("Cannot import MakePlots wrapper! Requires pandas and numpy")
+            else:
+                self.check_MakePlots_config(c_dict)
 
-            # create MakePlots wrapper instance
-            self.MakePlotsWrapper = MakePlotsWrapper(self.config, self.logger)
-            if not self.MakePlotsWrapper.isOK:
-                self.log_error("MakePlotsWrapper was not initialized correctly.")
+                # create MakePlots wrapper instance
+                self.MakePlotsWrapper = MakePlotsWrapper(self.config, self.logger)
+                if not self.MakePlotsWrapper.isOK:
+                    self.log_error("MakePlotsWrapper was not initialized correctly.")
 
         c_dict['VAR_LIST'] = util.parse_var_list(self.config)
 

--- a/ush/plotting_scripts/plot_util.py
+++ b/ush/plotting_scripts/plot_util.py
@@ -1,8 +1,9 @@
-import numpy as np
+import os
 import datetime as datetime
 import time
+import numpy as np
 import pandas as pd
-import os
+
 
 """!@namespace plot_util
  @brief Provides utility functions for METplus plotting use case.


### PR DESCRIPTION
I added multiple reviewers, but only 1 person needs to approve.

Closes #532 (again)

I added some additional logic in the problematic wrappers to catch the ModuleNotFoundError exception and set a variable to be used in the init step of the wrappers to report that extra modules are required to run. This allows all of the wrappers to be imported if they can and are simply skipped if they can't. The error will only be shown if the user tries to run the wrapper (added to PROCESS_LIST).

For future improvement, we could potentially try to wrap all imports for each wrapper in this way so that other wrappers could use additional packages beyond what is required to run METplus wrappers but not add dependencies if they are not being used by the user.