### PR TITLE
bugfix 379 master_v3.1 lower case d for day

### DIFF
--- a/docs/Users_Guide/systemconfiguration.rst
+++ b/docs/Users_Guide/systemconfiguration.rst
@@ -217,7 +217,7 @@ Examples::
     60M : 60 minutes or 3600 seconds
     1H : 1 hour or 3600 seconds
     1m : 1 month (relative)
-    1D : 1 day or 24 hours or 86400 seconds
+    1d : 1 day or 24 hours or 86400 seconds
     1Y : 1 year (relative)
 
 Units of months (m) and years (Y) do not have set intervals because the length of a month or year is relative to the relative date/time.


### PR DESCRIPTION
fixed typo in doc re: day is 1d not 1D

Very minor fix, so no need to create a bugfix release. Once this is approved/merged we can recreate the gh-pages documentation to include this fix.