### PR TITLE
bugfix develop plotter exception

### DIFF
--- a/metplus/wrappers/cyclone_plotter_wrapper.py
+++ b/metplus/wrappers/cyclone_plotter_wrapper.py
@@ -13,14 +13,16 @@ import collections
 
 # handle if module can't be loaded to run wrapper
 wrapper_cannot_run = False
+exception_err = ''
 try:
     import matplotlib.pyplot as plt
     import matplotlib.ticker as mticker
     import cartopy.crs as ccrs
     import cartopy.feature as cfeature
     from cartopy.mpl.gridliner import LONGITUDE_FORMATTER, LATITUDE_FORMATTER
-except ModuleNotFoundError as err_msg:
+except Exception as err_msg:
     wrapper_cannot_run = True
+    exception_err = err_msg
 
 import produtil.setup
 
@@ -39,8 +41,7 @@ class CyclonePlotterWrapper(CommandBuilder):
         super().__init__(config)
 
         if wrapper_cannot_run:
-            self.log_error("Cannot run CyclonePlotter wrapper due to import errors. "
-                           "matplotlib and cartopy are required to run.")
+            self.log_error(f"There was a problem importing modules: {exception_err}\n")
             return
 
         self.input_data = self.config.getdir('CYCLONE_PLOTTER_INPUT_DIR')

--- a/metplus/wrappers/make_plots_wrapper.py
+++ b/metplus/wrappers/make_plots_wrapper.py
@@ -23,11 +23,12 @@ from . import CommandBuilder
 
 # handle if module can't be loaded to run wrapper
 wrapper_cannot_run = False
+exception_err = ''
 try:
     from ush.plotting_scripts import plot_util
-except ModuleNotFoundError as err_msg:
+except Exception as err_msg:
     wrapper_cannot_run = True
-
+    exception_err = err_msg
 
 class MakePlotsWrapper(CommandBuilder):
     """! Wrapper to used to filter make plots from MET data
@@ -73,8 +74,7 @@ class MakePlotsWrapper(CommandBuilder):
         super().__init__(config)
 
         if wrapper_cannot_run:
-            self.log_error("Cannot run CyclonePlotter wrapper due to import errors. "
-                           "matplotlib and cartopy are required to run.")
+            self.log_error(f"There was a problem importing modules: {exception_err}\n")
             return
 
     def get_command(self):


### PR DESCRIPTION
Handle errors that come from imports better
Catch any Exception that comes from imports. Report error messages from exception only if plotter is initialized (found in the PROCESS_LIST).