### PR TITLE
Feature 595 docker work dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ env:
     - EXTRA_PACKAGES="pytest matplotlib numpy"
     - EXTRA_INSTALLS=test
     - OWNER_BUILD_DIR=`dirname ${TRAVIS_BUILD_DIR}`
-    - DOCKER_WORK_DIR=/root
+    - DOCKER_WORK_DIR=/metplus
 
     - GITHUB_REPO_ORG=DTCenter
     - DOCKERHUB_DEFAULT_REPO=dtcenter/metplus

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ env:
     - EXTRA_PACKAGES="pytest matplotlib numpy"
     - EXTRA_INSTALLS=test
     - OWNER_BUILD_DIR=`dirname ${TRAVIS_BUILD_DIR}`
-    - DOCKER_WORK_DIR=/metplus
+    - DOCKER_WORK_DIR=/root
 
     - GITHUB_REPO_ORG=DTCenter
     - DOCKERHUB_DEFAULT_REPO=dtcenter/metplus
@@ -147,7 +147,7 @@ matrix:
         - mkdir -p ${OWNER_BUILD_DIR}/pytmp.docker;
         - echo "DOCKERHUB_TAG is set to *${DOCKERHUB_TAG}*"
         - ${TRAVIS_BUILD_DIR}/ci/travis_jobs/docker_setup.sh
-        - docker run --rm -v ${OWNER_BUILD_DIR}:/metplus ${DOCKERHUB_TAG} /bin/bash -c "pip3 install pytest-cov; export METPLUS_PYTEST_HOST=docker; cd /metplus/METplus/internal_tests/pytests; pytest --cov=../../metplus"
+        - docker run --rm -v ${OWNER_BUILD_DIR}:${DOCKER_WORK_DIR} ${DOCKERHUB_TAG} /bin/bash -c "pip3 install pytest-cov; export METPLUS_PYTEST_HOST=docker; cd ${DOCKER_WORK_DIR}/METplus/internal_tests/pytests; pytest --cov=../../metplus"
         # Dump the output directories from running METplus
         - ls -alR ${OWNER_BUILD_DIR}/pytmp.docker
     - name: "Use Case Tests - met_tool_wrapper"

--- a/ci/travis_jobs/test_use_cases_met_tool_wrapper.sh
+++ b/ci/travis_jobs/test_use_cases_met_tool_wrapper.sh
@@ -62,7 +62,7 @@ rm -rf ${TRAVIS_OUTPUT_BASE}/logs
 mv ${TRAVIS_OUTPUT_BASE}/* ${TRAVIS_PREV_OUTPUT_BASE}/
 
 ### put cyclone plotter with cartopy and matplotlib
-${TRAVIS_BUILD_DIR}/ci/travis_jobs/docker_run_metplus.sh "${DOCKER_WORK_DIR}/METplus/ci/travis_jobs/get_cartopy.sh; pip3 install matplotlib; export DISPLAY=localhost:0.0; /metplus/METplus/internal_tests/use_cases/run_test_use_cases.sh docker --config met_tool_wrapper/CyclonePlotter/CyclonePlotter.conf,user_env_vars.MET_PYTHON_EXE=python3" $returncode
+${TRAVIS_BUILD_DIR}/ci/travis_jobs/docker_run_metplus.sh "${DOCKER_WORK_DIR}/METplus/ci/travis_jobs/get_cartopy.sh; pip3 install matplotlib; export DISPLAY=localhost:0.0; ${DOCKER_WORK_DIR}/METplus/internal_tests/use_cases/run_test_use_cases.sh docker --config met_tool_wrapper/CyclonePlotter/CyclonePlotter.conf,user_env_vars.MET_PYTHON_EXE=python3" $returncode
 returncode=$?
 
 echo 'Final return code=' $returncode 

--- a/ci/travis_jobs/test_use_cases_model_applications.sh
+++ b/ci/travis_jobs/test_use_cases_model_applications.sh
@@ -41,7 +41,7 @@ do
   
   # use docker_run_metplus.sh
 # use docker_run_metplus.sh
-    ${TRAVIS_BUILD_DIR}/ci/travis_jobs/docker_run_metplus.sh "${DOCKER_WORK_DIR}/METplus/ci/travis_jobs/get_pygrib.sh; pip3 install metpy; /metplus/METplus/internal_tests/use_cases/run_test_use_cases.sh docker --config model_applications/medium_range/TCStat_SeriesAnalysis_fcstGFS_obsGFS_FeatureRelative_SeriesByLead_PyEmbed_IVT.conf,user_env_vars.MET_PYTHON_EXE=python3" $returncode
+    ${TRAVIS_BUILD_DIR}/ci/travis_jobs/docker_run_metplus.sh "${DOCKER_WORK_DIR}/METplus/ci/travis_jobs/get_pygrib.sh; pip3 install metpy; ${DOCKER_WORK_DIR}/METplus/internal_tests/use_cases/run_test_use_cases.sh docker --config model_applications/medium_range/TCStat_SeriesAnalysis_fcstGFS_obsGFS_FeatureRelative_SeriesByLead_PyEmbed_IVT.conf,user_env_vars.MET_PYTHON_EXE=python3" $returncode
     returncode=$?
 
     # remove logs dir and move data to previous output base so next run will not prompt
@@ -54,7 +54,7 @@ do
 done
 
 if [ "$test_args" != "" ]; then
-    ${TRAVIS_BUILD_DIR}/ci/travis_jobs/docker_run_metplus.sh "/metplus/METplus/internal_tests/use_cases/run_test_use_cases.sh docker ${test_args}" $returncode
+    ${TRAVIS_BUILD_DIR}/ci/travis_jobs/docker_run_metplus.sh "${DOCKER_WORK_DIR}/METplus/internal_tests/use_cases/run_test_use_cases.sh docker ${test_args}" $returncode
     returncode=$?
 
   # remove logs dir and move data to previous output base so next run will not prompt

--- a/internal_tests/docker/Dockerfile
+++ b/internal_tests/docker/Dockerfile
@@ -29,17 +29,17 @@ RUN if [ -z ${MET_BRANCH+x} ]; then \
 #
 # Set working directory
 #
-WORKDIR /metplus
+#WORKDIR /metplus
 
 #
 # Environment for interactive bash and csh container shells
 #
 # container:/metplus is mounted to the host:/path/to/parent_of_METplus_dir
 # ie. -v /Users/Frimel/projects:/metplus  where /Users/Frimel/projects/METplus/ush
-RUN echo export PATH=$PATH:/metplus/METplus/ush >> /etc/bashrc \
- && echo setenv PATH $PATH:/metplus/METplus/ush >> /etc/csh.cshrc \
- && echo export PYTHONPATH=/metplus/METplus >> /etc/bashrc \
- && echo setenv PYTHONPATH /metplus/METplus >> /etc/csh.cshrc
+RUN echo export PATH=$PATH:/root/METplus/ush >> /etc/bashrc \
+ && echo setenv PATH $PATH:/root/METplus/ush >> /etc/csh.cshrc \
+ && echo export PYTHONPATH=/root/METplus >> /etc/bashrc \
+ && echo setenv PYTHONPATH /root/METplus >> /etc/csh.cshrc
 
 
 

--- a/internal_tests/docker/Dockerfile
+++ b/internal_tests/docker/Dockerfile
@@ -49,7 +49,7 @@ RUN echo export PATH=$PATH:${DOCKER_WORK_DIR}/METplus/ush >> /etc/bashrc \
 # && echo export METPLUS_DISABLE_PLOT_WRAPPERS=yes >> /etc/bashrc \
 # && echo setenv METPLUS_DISABLE_PLOT_WRAPPERS yes >> /etc/csh.cshrc
 ENV METPLUS_DISABLE_PLOT_WRAPPERS yes
-ENV DOCKER_WORK_DIR /root
+
 #
 # Install required packages: Pandas, Cartopy*
 #  - *dateutil, pytest

--- a/internal_tests/docker/Dockerfile
+++ b/internal_tests/docker/Dockerfile
@@ -29,17 +29,18 @@ RUN if [ -z ${MET_BRANCH+x} ]; then \
 #
 # Set working directory
 #
-#WORKDIR /metplus
+ENV DOCKER_WORK_DIR /metplus
+WORKDIR ${DOCKER_WORK_DIR}
 
 #
 # Environment for interactive bash and csh container shells
 #
 # container:/metplus is mounted to the host:/path/to/parent_of_METplus_dir
-# ie. -v /Users/Frimel/projects:/metplus  where /Users/Frimel/projects/METplus/ush
-RUN echo export PATH=$PATH:/root/METplus/ush >> /etc/bashrc \
- && echo setenv PATH $PATH:/root/METplus/ush >> /etc/csh.cshrc \
- && echo export PYTHONPATH=/root/METplus >> /etc/bashrc \
- && echo setenv PYTHONPATH /root/METplus >> /etc/csh.cshrc
+# ie. -v /Users/Frimel/projects:${DOCKER_WORK_DIR} where /Users/Frimel/projects/METplus/ush
+RUN echo export PATH=$PATH:${DOCKER_WORK_DIR}/METplus/ush >> /etc/bashrc \
+ && echo setenv PATH $PATH:${DOCKER_WORK_DIR}/METplus/ush >> /etc/csh.cshrc \
+ && echo export PYTHONPATH=${DOCKER_WORK_DIR}/METplus >> /etc/bashrc \
+ && echo setenv PYTHONPATH ${DOCKER_WORK_DIR}/METplus >> /etc/csh.cshrc
 
 
 

--- a/internal_tests/docker/Dockerfile
+++ b/internal_tests/docker/Dockerfile
@@ -48,7 +48,7 @@ RUN echo export PATH=$PATH:/root/METplus/ush >> /etc/bashrc \
 # && echo export METPLUS_DISABLE_PLOT_WRAPPERS=yes >> /etc/bashrc \
 # && echo setenv METPLUS_DISABLE_PLOT_WRAPPERS yes >> /etc/csh.cshrc
 ENV METPLUS_DISABLE_PLOT_WRAPPERS yes
-
+ENV DOCKER_WORK_DIR /root
 #
 # Install required packages: Pandas, Cartopy*
 #  - *dateutil, pytest

--- a/internal_tests/use_cases/metplus_test_env.docker.sh
+++ b/internal_tests/use_cases/metplus_test_env.docker.sh
@@ -6,13 +6,13 @@ export METPLUS_TEST_METPLUS_BASE=
 export METPLUS_TEST_MET_INSTALL_DIR=/usr/local
 
 # location to write output from test run
-export METPLUS_TEST_OUTPUT_BASE=/metplus/test-use-case-output
+export METPLUS_TEST_OUTPUT_BASE=${DOCKER_WORK_DIR}/test-use-case-output
 
 # location of output from previous test run to compare to current run
-export METPLUS_TEST_PREV_OUTPUT_BASE=/metplus/test-use-case-output-old
+export METPLUS_TEST_PREV_OUTPUT_BASE=${DOCKER_WORK_DIR}/test-use-case-output-old
 
 # location of input data to use in tests
-export METPLUS_TEST_INPUT_BASE=/metplus/test.metplus.data
+export METPLUS_TEST_INPUT_BASE=${DOCKER_WORK_DIR}/test.metplus.data
 
 # location of GempakToCF to run tests that use Gempak
 export METPLUS_TEST_GEMPAKTOCF_JAR=${METPLUS_TEST_INPUT_BASE}/GempakToCF.jar


### PR DESCRIPTION
* Changed DOCKER_WORK_DIR in .travis.yml from /metplus to /root
* Changed all instances of /metplus in the Travis scripts to $DOCKER_WORK_DIR
* Set environment variable DOCKER_WORK_DIR to /root in the Dockerfile
* Reference $DOCKER_WORK_DIR in use case test environment file used for Docker