### PR TITLE
master v3.1 error message for old python version

### DIFF
--- a/metplus/util/__init__.py
+++ b/metplus/util/__init__.py
@@ -1,6 +1,6 @@
+from .metplus_check import *
 from .time_util import *
 from .met_util import *
-from .metplus_check import *
 from .config.config_launcher import *
 from .config.config_metplus import *
 from .config.string_template_substitution import *


### PR DESCRIPTION
moved metplus_check to top of metplus util init file so that useful error message is shown if using a version of python that is before the requirement

To test - using previous version of master_v3.1 with python 2 (or anything less than 3.6.3) will output a SyntaxError for f-strings. The new version should report a useful error message.