### PR TITLE
Feature 485 no metplus data plot wrappers

### DIFF
--- a/internal_tests/docker/Dockerfile
+++ b/internal_tests/docker/Dockerfile
@@ -47,7 +47,7 @@ RUN echo export PATH=$PATH:/metplus/METplus/ush >> /etc/bashrc \
 # 
 # && echo export METPLUS_DISABLE_PLOT_WRAPPERS=yes >> /etc/bashrc \
 # && echo setenv METPLUS_DISABLE_PLOT_WRAPPERS yes >> /etc/csh.cshrc
-#ENV METPLUS_DISABLE_PLOT_WRAPPERS yes
+ENV METPLUS_DISABLE_PLOT_WRAPPERS yes
 
 #
 # Install required packages: Pandas, Cartopy*

--- a/internal_tests/docker/Dockerfile
+++ b/internal_tests/docker/Dockerfile
@@ -47,7 +47,7 @@ RUN echo export PATH=$PATH:/metplus/METplus/ush >> /etc/bashrc \
 # 
 # && echo export METPLUS_DISABLE_PLOT_WRAPPERS=yes >> /etc/bashrc \
 # && echo setenv METPLUS_DISABLE_PLOT_WRAPPERS yes >> /etc/csh.cshrc
-ENV METPLUS_DISABLE_PLOT_WRAPPERS yes
+#ENV METPLUS_DISABLE_PLOT_WRAPPERS yes
 
 #
 # Install required packages: Pandas, Cartopy*

--- a/internal_tests/docker/Dockerfile
+++ b/internal_tests/docker/Dockerfile
@@ -47,9 +47,8 @@ RUN echo export PATH=$PATH:/metplus/METplus/ush >> /etc/bashrc \
 # 
 # && echo export METPLUS_DISABLE_PLOT_WRAPPERS=yes >> /etc/bashrc \
 # && echo setenv METPLUS_DISABLE_PLOT_WRAPPERS yes >> /etc/csh.cshrc
-#ENV METPLUS_DISABLE_PLOT_WRAPPERS yes
 
-#
+
 # Install required packages: Pandas, Cartopy*
 #  - *dateutil, pytest
 #

--- a/internal_tests/use_cases/test_use_cases.py
+++ b/internal_tests/use_cases/test_use_cases.py
@@ -175,7 +175,12 @@ def run_test_use_case(param, test_metplus_base):
     global failed_runs
 
     params, p = get_params(param)
-    out_dir = os.path.join(p.getdir('OUTPUT_BASE'), os.path.basename(params[-2]))
+
+    # get list of actual param files (ignoring config value overrides)
+    # to the 2nd last file to use as the output directory
+    # last param file is always the system.conf file
+    param_files = [param for param in params if os.path.exists(param)]
+    out_dir = os.path.join(p.getdir('OUTPUT_BASE'), os.path.basename(param_files[-2]))
 
     cmd = os.path.join(test_metplus_base, "ush", "master_metplus.py")
     for parm in params:
@@ -247,8 +252,27 @@ def main():
     parser.add_argument('--space_weather', action='store_true', required=False)
     parser.add_argument('--tc_and_extra_tc', action='store_true', required=False)
     parser.add_argument('--all', action='store_true', required=False)
+    parser.add_argument('--config', action='append', required=False)
 
     args = parser.parse_args()
+    print(args.config)
+
+    if args.config:
+        for use_case in args.config:
+            config_args = use_case.split(',')
+            config_list = []
+            for config_arg in config_args:
+                # if relative path, must be relative to parm/use_cases
+                if not os.path.isabs(config_arg):
+                    # check that the full path exists before adding
+                    # use_case_dir in case item is a config value override
+                    check_config_exists = os.path.join(use_case_dir, config_arg)
+                    if os.path.exists(check_config_exists):
+                        config_arg = check_config_exists
+
+                config_list.append(config_arg)
+
+            force_use_cases_to_run.append(','.join(config_list))
 
     # compile list of use cases to run
     use_cases_to_run = []

--- a/internal_tests/use_cases/test_use_cases.py
+++ b/internal_tests/use_cases/test_use_cases.py
@@ -146,10 +146,8 @@ use_cases['tc_and_extra_tc'] = [
     use_case_dir + "/model_applications/tc_and_extra_tc/TCRMW_fcstGFS_fcstOnly_gonzalo.conf",
 ]
 
-#tea The use cases below require additional dependencies and are no longer in the use_cases section
-#    They can be run using the --config option
-
-#if plot_wrappers_are_enabled(os.environ):
+# The use cases below require additional dependencies and are no longer run via the use_cases dictionary
+# They can be run using the --config option if needed
 #    use_cases['met_tool_wrapper'].append(use_case_dir + "/met_tool_wrapper/CyclonePlotter/CyclonePlotter.conf")
 #    use_cases['met_tool_wrapper'].append(use_case_dir + "/met_tool_wrapper/TCMPRPlotter/TCMPRPlotter.conf")
 #    use_cases['tc_and_extra_tc'].append(use_case_dir + "/model_applications/tc_and_extra_tc/Plotter_fcstGFS_obsGFS_ExtraTC.conf")

--- a/internal_tests/use_cases/test_use_cases.py
+++ b/internal_tests/use_cases/test_use_cases.py
@@ -27,7 +27,7 @@ import calendar
 import argparse
 
 from metplus.util import config_metplus
-from metplus.util.metplus_check import plot_wrappers_are_enabled
+#from metplus.util.metplus_check import plot_wrappers_are_enabled
 
 # keep track of use cases that failed to report at the end of execution
 failed_runs = []
@@ -148,11 +148,11 @@ use_cases['tc_and_extra_tc'] = [
 ]
 
 # if plot wrappers are enabled, add those use cases to the test lists
-if plot_wrappers_are_enabled(os.environ):
-    use_cases['met_tool_wrapper'].append(use_case_dir + "/met_tool_wrapper/CyclonePlotter/CyclonePlotter.conf")
-    use_cases['met_tool_wrapper'].append(use_case_dir + "/met_tool_wrapper/TCMPRPlotter/TCMPRPlotter.conf")
-    use_cases['tc_and_extra_tc'].append(use_case_dir + "/model_applications/tc_and_extra_tc/Plotter_fcstGFS_obsGFS_ExtraTC.conf")
-    use_cases['tc_and_extra_tc'].append(use_case_dir + "/model_applications/tc_and_extra_tc/Plotter_fcstGFS_obsGFS_RPlotting.conf")
+#if plot_wrappers_are_enabled(os.environ):
+#    use_cases['met_tool_wrapper'].append(use_case_dir + "/met_tool_wrapper/CyclonePlotter/CyclonePlotter.conf")
+#    use_cases['met_tool_wrapper'].append(use_case_dir + "/met_tool_wrapper/TCMPRPlotter/TCMPRPlotter.conf")
+#    use_cases['tc_and_extra_tc'].append(use_case_dir + "/model_applications/tc_and_extra_tc/Plotter_fcstGFS_obsGFS_ExtraTC.conf")
+#    use_cases['tc_and_extra_tc'].append(use_case_dir + "/model_applications/tc_and_extra_tc/Plotter_fcstGFS_obsGFS_RPlotting.conf")
 
 def get_param_list(param):
     conf = metplus_home+"/internal_tests/use_cases/system.conf"

--- a/internal_tests/use_cases/test_use_cases.py
+++ b/internal_tests/use_cases/test_use_cases.py
@@ -27,7 +27,6 @@ import calendar
 import argparse
 
 from metplus.util import config_metplus
-#from metplus.util.metplus_check import plot_wrappers_are_enabled
 
 # keep track of use cases that failed to report at the end of execution
 failed_runs = []
@@ -147,7 +146,9 @@ use_cases['tc_and_extra_tc'] = [
     use_case_dir + "/model_applications/tc_and_extra_tc/TCRMW_fcstGFS_fcstOnly_gonzalo.conf",
 ]
 
-# if plot wrappers are enabled, add those use cases to the test lists
+#tea The use cases below require additional dependencies and are no longer in the use_cases section
+#    They can be run using the --config option
+
 #if plot_wrappers_are_enabled(os.environ):
 #    use_cases['met_tool_wrapper'].append(use_case_dir + "/met_tool_wrapper/CyclonePlotter/CyclonePlotter.conf")
 #    use_cases['met_tool_wrapper'].append(use_case_dir + "/met_tool_wrapper/TCMPRPlotter/TCMPRPlotter.conf")


### PR DESCRIPTION

Commented out line in Dockerfile: ENV METPLUS_DISABLE_PLOT_WRAPPERS yes
Commented out line in test_use_cases.py: from metplus.util.metplus_check import plot_wrappers_are_enabled
Commnted out block in test_use_cases.py:# if plot wrappers are enabled, add those use cases to the test lists
#if plot_wrappers_are_enabled(os.environ):

use_cases['met_tool_wrapper'].append(use_case_dir + "/met_tool_wrapper/CyclonePlotter/CyclonePlotter.conf")
use_cases['met_tool_wrapper'].append(use_case_dir + "/met_tool_wrapper/TCMPRPlotter/TCMPRPlotter.conf")
use_cases['tc_and_extra_tc'].append(use_case_dir + "/model_applications/tc_and_extra_tc/Plotter_fcstGFS_obsGFS_ExtraTC.conf")
use_cases['tc_and_extra_tc'].append(use_case_dir + "/model_applications/tc_and_extra_tc/Plotter_fcstGFS_obsGFS_RPlotting.conf")