### PR TITLE
Feature 636 docker_data

### DIFF
--- a/ci/docker/docker_data/Dockerfile
+++ b/ci/docker/docker_data/Dockerfile
@@ -1,10 +1,8 @@
 FROM centos:7
 MAINTAINER George McCabe <mccabe@ucar.edu>
 
-# Required argument
+# Required arguments
 ARG TARFILE_URL
-
-# Optional argument
 ARG MOUNTPT
 
 # Check that TARFILE_URL is defined.
@@ -13,7 +11,13 @@ RUN if [ "x${TARFILE_URL}" == "x" ]; then \
       exit 1; \
     fi
 
-ENV CASE_DIR /data/input/METplus_Data
+# Check that MOUNTPT is defined.
+RUN if [ "x${MOUNTPT}" == "x" ]; then \
+      echo "ERROR: MOUNTPT undefined! Rebuild with \"--build-arg MOUNTPT={VOLUME mount directory}\""; \
+      exit 1; \
+    fi
+
+ENV CASE_DIR=/data/input/METplus_Data
 RUN mkdir -p ${CASE_DIR}
 
 RUN for URL in `echo ${TARFILE_URL} | tr "," " "`; do \
@@ -21,24 +25,8 @@ RUN for URL in `echo ${TARFILE_URL} | tr "," " "`; do \
       curl -SL ${URL} | tar -xzC ${CASE_DIR}; \
     done
 
-# Check that .VOLUME exists, if necessary.
-RUN if [ "x${MOUNTPT}" == "x" ]; then \
-      VOLUME_FILE=`find /data/input/METplus_Data -name .VOLUME | head -1`; \
-      if [ "x${VOLUME_FILE}" == "x" ]; then \
-        echo "ERROR: Required .VOLUME file not found!"; \
-        exit 1; \
-      fi; \
-      MOUNTPT=`dirname ${VOLUME_FILE}`; \
-    fi; \
-    echo "Mounting directory: ${MOUNTPT}"
-
 # Define the volume mount point
-VOLUME if [ "x${MOUNTPT}" == "x" ]; then \
-         VOLUME_FILE=`find /data/input/METplus_Data -name .VOLUME | head -1`; \
-         echo `dirname ${VOLUME_FILE}`; \
-       else; \
-         echo ${MOUNTPT}; \
-       fi
+VOLUME ${MOUNTPT}
 
 USER root
 CMD ["true"]

--- a/ci/docker/docker_data/Dockerfile
+++ b/ci/docker/docker_data/Dockerfile
@@ -1,31 +1,45 @@
 FROM centos:7
 MAINTAINER George McCabe <mccabe@ucar.edu>
 
-# Required arguments
-ARG TARFILE
+# Required argument
+ARG TARFILE_URL
+
+# Optional argument
 ARG MOUNTPT
 
-# Check that TARFILE is defined.
-RUN if [ "x${TARFILE}" == "x" ]; then \
-      echo "ERROR: TARFILE undefined! Rebuild with \"--build-arg TARFILE={One or more input tarfiles}\""; \
-      exit 1; \
-    fi
-
-# Check that MOUNTPT is defined.
-RUN if [ "x${MOUNTPT}" == "x" ]; then \
-      echo "ERROR: MOUNTPT undefined! Rebuild with \"--build-arg MOUNTPT={Mount point directory}\""; \
+# Check that TARFILE_URL is defined.
+RUN if [ "x${TARFILE_URL}" == "x" ]; then \
+      echo "ERROR: TARFILE_URL undefined! Rebuild with \"--build-arg TARFILE_URL={One or more URL's}\""; \
       exit 1; \
     fi
 
 ENV CASE_DIR /data/input/METplus_Data
 RUN mkdir -p ${CASE_DIR}
 
-RUN for CUR_TARFILE in `echo ${TARFILE} | tr "," " "`; do \
-      echo "Downloading: ${CUR_TARFILE}"; \
-      curl -SL https://dtcenter.ucar.edu/dfiles/code/METplus/METplus_Data/${CUR_TARFILE} | tar -xzC ${CASE_DIR}; \
+RUN for URL in `echo ${TARFILE_URL} | tr "," " "`; do \
+      echo "Downloading: ${URL}"; \
+      curl -SL ${URL} | tar -xzC ${CASE_DIR}; \
     done
 
-VOLUME ${MOUNTPT}
+# Check that .VOLUME exists, if necessary.
+RUN if [ "x${MOUNTPT}" == "x" ]; then \
+      VOLUME_FILE=`find /data/input/METplus_Data -name .VOLUME | head -1`; \
+      if [ "x${VOLUME_FILE}" == "x" ]; then \
+        echo "ERROR: Required .VOLUME file not found!"; \
+        exit 1; \
+      fi; \
+      MOUNTPT=`dirname ${VOLUME_FILE}`; \
+    fi; \
+    echo "Mounting directory: ${MOUNTPT}"
+
+# Define the volume mount point
+VOLUME if [ "x${MOUNTPT}" == "x" ]; then \
+         VOLUME_FILE=`find /data/input/METplus_Data -name .VOLUME | head -1`; \
+         echo `dirname ${VOLUME_FILE}`; \
+       else; \
+         echo ${MOUNTPT}; \
+       fi
+
 USER root
 CMD ["true"]
 

--- a/ci/docker/docker_data/build_docker_images.sh
+++ b/ci/docker/docker_data/build_docker_images.sh
@@ -3,92 +3,202 @@
 # Build METplus-Data Docker images for sample data tarballs
 #=======================================================================
 #
-# This script reads the metplus_sample_data file as input.
-# For each entry, formatted as follows:
-#   <dataset name>:<tarfile>:<path to data volume mount point>
-# It creates a Docker data volume image named:
-#   dtcenter/metplus-data:<version>-<dataset name>
+# This script pulls sample data tarfiles from:
+#   https://dtcenter.ucar.edu/dfiles/code/METplus/METplus_Data/<version>
 #
-# For example, the metplus_sample_data entry:
-#   s2s:develop/sample_data-s2s.tgz:/data/input/METplus_Data/model_applications/s2s
-# Creates an image named:
-#   dtcenter/metplus-data:develop-s2s
+# Where <version> is specified using the required "-pull" command line
+# option. It searches for tarfiles in that directory named
+# "sample_data-<dataset name>.tgz". When the "-data" option is used,
+# it only processes the specified list of datasets. Otherwise, it
+# processes all datasets in that directory.
 #
-# If the optional -push command line option is used, all images created
-# are automatically pushed to DockerHub.
+# The tarfile for each dataset must contain an empty hidden file named
+# ".VOLUME" which indicate the directory to be mounted for the Docker
+# data volume.
 #
-# Usage: build_docker_images.sh [-version name] [-push]
-#   where -version name overrides the default METplus version (develop)
-#         -push pushes the images to DockerHub
+# For each datasest, it builds a Docker data volume. The tarfile for
+# each dataset must contain an empty hidden file named ".VOLUME" which
+# which indicates the directory to be mounted for the Docker data
+# volume.
+#
+# When "-union" is used, it also builds a Docker data volume for all
+# datasets in that directory. When "-push" is used, it pushes the
+# resulting images to the specified DockerHub repository.
+#
+# See Usage statement below.
 #
 #=======================================================================
 
-# Defaults for command line options
-METPLUS_VERSION=develop
-DO_PUSH=0
+# Constants
+SCRIPT_DIR=$(dirname $0)
+PULL_URL="https://dtcenter.ucar.edu/dfiles/code/METplus/METplus_Data"
 
-# Process arguments
-for ARG in "$@"; do
+#
+# Usage statement for this script
+#
+function usage {
+  cat << EOF
 
-  # Pushing to DockerHub
-  if [ $ARG == "push" -o $ARG == "-push" -o $ARG == "--push" ]; then
-    DO_PUSH=1
-    echo "Will push images to DockerHub."
+Usage: build_docker_images.sh
+        -pull version
+        [-data list]
+        [-union]
+        [-push repo]
+        [-help]
 
-  # METplus Version
-  elif [ $ARG == "version" -o $ARG == "-version" -o $ARG == "--version" ]; then
-    shift
-    METPLUS_VERSION=$1
-    echo "Will create images for METPLUS_VERSION = ${METPLUS_VERSION}."
-  fi
+        where:
+          "-pull version" defines the version of the datasets to be pulled (required).
+          "-data list" overrides the use of all datasets for this version with a comma-separated list (optional).
+          "-union" also creates one data volume with all datasets for this version (optional).
+          "-push repo" pushes the images to the specified DockerHub repository (optional).
+          "-help" prints the usage statement.
 
-done
+  e.g. Pull from ${PULL_URL}/<version>
+       Push to DockerHub <repo>:<version>-<data>
 
-# Define a command runner utility to check return status
+EOF
+
+  exit 1
+}
+
+#
+# Command runner utility function
+#
 function run_command {
   echo "RUNNING: $*"
   $*
   error=$?
   if [ ${error} -ne 0 ]; then
+    echo "ERROR:"
     echo "ERROR: '$*' exited with status = ${error}"
+    echo "ERROR:"
     exit ${error}
   fi
 }
 
-# Script directory
-SCRIPT_DIR=$(dirname $0)
+# Defaults for command line options
+DO_UNION=0
+DO_PUSH=0
 
-#
-# Build separate image for each tarfile
-#
+# Parse command line options
+while true; do
+  case "$1" in
 
-for ASSET in $(cat ${SCRIPT_DIR}/metplus_sample_data); do
+    pull | -pull | --pull )
+      VERSION=$2
+      echo "Will pull data from ${PULL_URL}/${VERSION}"
+      shift 2;;
 
-  IMGNAME="dtcenter/metplus-data:${METPLUS_VERSION}-`echo ${ASSET} | cut -d':' -f1`"
-  TARFILE=`echo ${ASSET} | cut -d':' -f2`
-  MOUNTPT=`echo ${ASSET} | cut -d':' -f3`
+    data | -data | --data )
+      if [ -z ${PULL_DATA+x} ]; then
+        PULL_DATA=$2
+      else
+        PULL_DATA="${PULL_DATA},$2"
+      fi
+      shift 2;;
 
-  # Build a list of tarfiles
-  if [ -z ${TARFILE_LIST+x} ]; then
-    TARFILE_LIST=${TARFILE}
+    union | -union | --union )
+      DO_UNION=1
+      echo "Will create a data volume containing all input datasets."
+      shift;;
+
+    push | -push | --push )
+      DO_PUSH=1
+      PUSH_REPO=$2
+      echo "Will push images to DockerHub ${PUSH_REPO}."
+      shift 2;;
+
+    help | -help | --help )
+      usage
+      shift;;
+
+    -* )
+      echo "ERROR:"
+      echo "ERROR: Unsupported option: $1"
+      echo "ERROR:"
+      usage;;
+
+    * )
+      break;;
+
+  esac
+done
+
+# Check that the version has been specified
+if [ -z ${VERSION+x} ]; then
+  echo "ERROR:"
+  echo "ERROR: The '-pull' option is required!"
+  echo "ERROR:"
+  usage
+fi
+
+# Define the target repository if necessary 
+if [ -z ${PUSH_REPO+x} ]; then
+
+  # Push tagged versions (e.g. v4.0) to metplus-data
+  # and all others to metplus-data-dev
+  if [[ ${VERSION} =~ ^v[0-9.]+$ ]]; then
+    PUSH_REPO="dtcenter/metplus-data"
   else
-    TARFILE_LIST=${TARFILE_LIST},${TARFILE}
+    PUSH_REPO="dtcenter/metplus-data-dev"
   fi
+fi 
+
+# Print the datasets to be processed
+if [ -z ${PULL_DATA+x} ]; then
+  echo "Will process all available datasets."
+else
+  echo "Will process the following datasets: ${PULL_DATA}"
+fi
+
+# Get list of available tarfiles
+TARFILE_LIST=`curl -s ${PULL_URL}/${VERSION}/ | tr "<>" "\n" | egrep sample_data | egrep -v href`
+
+if [[ ${TARFILE_LIST} == "" ]]; then
+  echo "ERROR:"
+  echo "ERROR: No tarfiles found in ${PULL_URL}/${VERSION}/"
+  echo "ERROR:"
+  exit 1
+fi
+
+# Build separate image for each tarfile
+for TARFILE in $TARFILE_LIST; do 
+
+  # Build a list of all URL's
+  CUR_URL="${PULL_URL}/${VERSION}/${TARFILE}"
+
+  if [ -z ${URL_LIST+x} ]; then
+    URL_LIST=${CUR_URL}
+  else
+    URL_LIST="${URL_LIST},${CUR_URL}"
+  fi
+
+  # Parse the current dataset name
+  CUR_DATA=`echo $TARFILE | cut -d'-' -f2 | sed 's/.tgz//g'`
+
+  if [ -z ${PULL_DATA+x} ] || [ `echo ${PULL_DATA} | grep ${CUR_DATA}` ]; then
+    echo "Processing \"${TARFILE}\" ..." 
+  else
+    echo "Skipping \"${TARFILE}\" since \"${CUR_DATA}\" was not requested in \"-data\"." 
+    continue 
+  fi
+
+  # Define the docker image name
+  IMGNAME="${PUSH_REPO}:${VERSION}-${CUR_DATA}"
 
   echo
   echo "Building image ... ${IMGNAME}" 
   echo
 
   run_command docker build -t ${IMGNAME} . \
-    --build-arg TARFILE=${TARFILE} \
-    --build-arg MOUNTPT=${MOUNTPT}
+    --build-arg TARFILE_URL=${CUR_URL}
 
   if [ ${DO_PUSH} == 1 ]; then
     echo
     echo "Pushing image ... ${IMGNAME}"
     echo
 
-    run_command docker push ${IMGNAME} 
+    run_command docker push ${IMGNAME}
 
   fi
 
@@ -98,19 +208,22 @@ done
 # Build one image for all tarfiles
 #
 
-IMGNAME="dtcenter/metplus-data:${METPLUS_VERSION}"
-MOUNTPT="/data/input/METplus_Data"
+if [ ${DO_UNION} == 1 ]; then
 
-run_command docker build -t ${IMGNAME} . \
-  --build-arg TARFILE=${TARFILE_LIST} \
-  --build-arg MOUNTPT=${MOUNTPT}
+  IMGNAME="${PUSH_REPO}:${VERSION}"
+  MOUNTPT="/data/input/METplus_Data"
 
-if [ ${DO_PUSH} == 1 ]; then
-  echo
-  echo "Pushing image ... ${IMGNAME}"
-  echo
+  run_command docker build -t ${IMGNAME} . \
+    --build-arg TARFILE_URL=${URL_LIST} \
+    --build-arg MOUNTPT=${MOUNTPT}
 
-  run_command docker push ${IMGNAME}
+  if [ ${DO_PUSH} == 1 ]; then
+    echo
+    echo "Pushing image ... ${IMGNAME}"
+    echo
 
+    run_command docker push ${IMGNAME}
+
+  fi
 fi
 

--- a/ci/docker/docker_data/hooks/build
+++ b/ci/docker/docker_data/hooks/build
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./build_docker_images.sh --version $SOURCE_BRANCH --push
+./build_docker_images.sh -version $SOURCE_BRANCH -union -push dtcenter/metplus_data

--- a/ci/docker/docker_data/hooks/build
+++ b/ci/docker/docker_data/hooks/build
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./build_docker_images.sh -version $SOURCE_BRANCH -union -push dtcenter/metplus_data
+./build_docker_images.sh -version $SOURCE_BRANCH -union -push dtcenter/metplus-data

--- a/ci/docker/docker_data/metplus_sample_data
+++ b/ci/docker/docker_data/metplus_sample_data
@@ -1,9 +1,0 @@
-met_tool_wrapper:develop/sample_data-met_tool_wrapper.tgz:/data/input/METplus_Data/met_test
-convection_allowing_models:develop/sample_data-convection_allowing_models.tgz:/data/input/METplus_Data/model_applications/convection_allowing_models
-climate:develop/sample_data-climate.tgz:/data/input/METplus_Data/model_applications/climate
-cryosphere:develop/sample_data-cryosphere.tgz:/data/input/METplus_Data/model_applications/cryosphere
-medium_range:develop/sample_data-medium_range.tgz:/data/input/METplus_Data/model_applications/medium_range
-precipitation:develop/sample_data-precipitation.tgz:/data/input/METplus_Data/model_applications/precipitation
-s2s:develop/sample_data-s2s.tgz:/data/input/METplus_Data/model_applications/s2s
-space_weather:develop/sample_data-space_weather.tgz:/data/input/METplus_Data/model_applications/space_weather
-tc_and_extra_tc:develop/sample_data-tc_and_extra_tc.tgz:/data/input/METplus_Data/model_applications/tc_and_extra_tc

--- a/ci/travis_jobs/get_data_volumes.py
+++ b/ci/travis_jobs/get_data_volumes.py
@@ -22,7 +22,7 @@ def main():
     volume_list = []
 
     dockerhub_repo = 'metplus-data'
-    if METPLUS_VERSION.startswith('v'):
+    if not METPLUS_VERSION.startswith('v'):
         dockerhub_repo = f'{dockerhub_repo}-dev'
 
     for model_app_name in MODEL_APP_NAMES:

--- a/ci/travis_jobs/get_data_volumes.py
+++ b/ci/travis_jobs/get_data_volumes.py
@@ -21,6 +21,10 @@ MODEL_APP_NAMES = ('met_tool_wrapper',
 def main():
     volume_list = []
 
+    dockerhub_repo = 'metplus-data'
+    if METPLUS_VERSION.startswith('v'):
+        dockerhub_repo = f'{dockerhub_repo}-dev'
+
     for model_app_name in MODEL_APP_NAMES:
 
         # if model application name if found in any command line argument.
@@ -35,7 +39,7 @@ def main():
             else:
                 volume_name = f'{METPLUS_VERSION}-{model_app_name}'
 
-            cmd = f'docker pull dtcenter/metplus-data:{volume_name}'
+            cmd = f'docker pull dtcenter/{dockerhub_repo}:{volume_name}'
             ret = subprocess.run(shlex.split(cmd), stdout=subprocess.DEVNULL)
 
             # if return code is non-zero, a failure occurred
@@ -43,7 +47,7 @@ def main():
                 return f'Command failed: {cmd}'
 
             cmd = (f'docker create --name {model_app_name} '
-                   f'dtcenter/metplus-data:{volume_name}')
+                   f'dtcenter/{dockerhub_repo}:{volume_name}')
             ret = subprocess.run(shlex.split(cmd), stdout=subprocess.DEVNULL)
 
             if ret.returncode:


### PR DESCRIPTION
This fixes the docker data build script to run well with Travis.
Tags for the develop branch now live in dtcenter/metplus-data-dev.
Tags for released versions live in dtcenter/metplus-data.

I would also like to delete the leftover tags for develop in dtcenter/metplus-data, but will wait until Todd confirms that I can do so without breaking Travis. So we likely need to complete #633 before deleting them.