### PR TITLE
feature 620 nbrhd.cov_thresh in GridStat

### DIFF
--- a/docs/Users_Guide/glossary.rst
+++ b/docs/Users_Guide/glossary.rst
@@ -2619,6 +2619,13 @@ METplus Configuration Glossary
      | *Family:*  [config]
      | *Default:* 1
 
+   GRID_STAT_NEIGHBORHOOD_COV_THRESH
+     Sets the neighborhood cov_thresh list used by GridStat. See `MET User's Guide <https://dtcenter.org/community-code/model-evaluation-tools-met/documentation>`_ for more information.
+
+     | *Used by:*  GridStat
+     | *Family:*  [config]
+     | *Default:* None
+
    POINT_STAT_NEIGHBORHOOD_WIDTH
      Sets the neighborhood width used by PointStat. See `MET User's Guide <https://dtcenter.org/community-code/model-evaluation-tools-met/documentation>`_ for more information.
 

--- a/docs/Users_Guide/wrappers.rst
+++ b/docs/Users_Guide/wrappers.rst
@@ -515,6 +515,7 @@ Configuration
 | :term:`OBS_GRID_STAT_PROB_THRESH` (optional) 
 | :term:`GRID_STAT_NEIGHBORHOOD_WIDTH` (optional)
 | :term:`GRID_STAT_NEIGHBORHOOD_SHAPE` (optional)
+| :term:`GRID_STAT_NEIGHBORHOOD_COV_THRESH` (optional)
 | :term:`FCST_GRID_STAT_WINDOW_BEGIN` (optional) 
 | :term:`FCST_GRID_STAT_WINDOW_END` (optional) 
 | :term:`OBS_GRID_STAT_WINDOW_BEGIN` (optional) 

--- a/metplus/wrappers/command_builder.py
+++ b/metplus/wrappers/command_builder.py
@@ -1114,7 +1114,7 @@ class CommandBuilder:
         dict_string += '}'
         return dict_string
 
-    def set_c_dict_list(self, c_dict, mp_config_name, met_config_name, c_dict_key=None):
+    def set_c_dict_list(self, c_dict, mp_config_name, met_config_name, c_dict_key=None, remove_quotes=False):
         """! Get list from METplus configuration file and format it to be passed
               into a MET configuration file. Set c_dict item with formatted string.
              Args:
@@ -1129,6 +1129,9 @@ class CommandBuilder:
         conf_value = util.getlist(self.config.getstr('config', mp_config_name, ''))
         if conf_value:
             conf_value = str(conf_value).replace("'", '"')
+
+            if remove_quotes:
+                conf_value = conf_value.replace('"', '')
 
             if not c_dict_key:
                 c_key = met_config_name.upper()

--- a/metplus/wrappers/grid_stat_wrapper.py
+++ b/metplus/wrappers/grid_stat_wrapper.py
@@ -76,6 +76,12 @@ class GridStatWrapper(CompareGriddedWrapper):
                                                           'GRID_STAT_NEIGHBORHOOD_WIDTH', '1')
         c_dict['NEIGHBORHOOD_SHAPE'] = self.config.getstr('config',
                                                           'GRID_STAT_NEIGHBORHOOD_SHAPE', 'SQUARE')
+        self.set_c_dict_list(c_dict,
+                             f'GRID_STAT_NEIGHBORHOOD_COV_THRESH',
+                             'cov_thresh',
+                             'NEIGHBORHOOD_COV_THRESH',
+                             remove_quotes=True)
+
         c_dict['VERIFICATION_MASK_TEMPLATE'] = \
             self.config.getraw('filename_templates',
                                'GRID_STAT_VERIFICATION_MASK_TEMPLATE')
@@ -107,6 +113,9 @@ class GridStatWrapper(CompareGriddedWrapper):
 
         self.add_env_var('NEIGHBORHOOD_SHAPE',
                          self.c_dict['NEIGHBORHOOD_SHAPE'])
+
+        self.add_env_var('NEIGHBORHOOD_COV_THRESH',
+                         self.c_dict.get('NEIGHBORHOOD_COV_THRESH', ''))
 
         self.add_env_var('VERIF_MASK',
                          self.c_dict.get('VERIFICATION_MASK', ''))

--- a/parm/met_config/GridStatConfig_wrapped
+++ b/parm/met_config/GridStatConfig_wrapped
@@ -148,7 +148,7 @@ nbrhd = {
    field      = BOTH;
    shape      = ${NEIGHBORHOOD_SHAPE};
    width      = [ ${NEIGHBORHOOD_WIDTH} ];
-   cov_thresh = [ >=0.5 ];
+   ${NEIGHBORHOOD_COV_THRESH}
    vld_thresh = 1.0;
 }
 

--- a/parm/use_cases/met_tool_wrapper/GridStat/GridStat.conf
+++ b/parm/use_cases/met_tool_wrapper/GridStat/GridStat.conf
@@ -107,6 +107,9 @@ GRID_STAT_NEIGHBORHOOD_WIDTH = 1
 # shape value passed to nbrhd dictionary in the MET config file
 GRID_STAT_NEIGHBORHOOD_SHAPE = SQUARE
 
+# cov thresh list passed to nbrhd dictionary in the MET config file
+GRID_STAT_NEIGHBORHOOD_COV_THRESH = >=0.5
+
 # Set to true to run GridStat separately for each field specified
 # Set to false to create one run of GridStat per run time that
 #   includes all fields specified.


### PR DESCRIPTION
added support for neighborhood cov_thresh in GridStat. I had to modify the function that gets a list from the config files to add an option to remove quotes so the threshold values would be formatted correctly.