### PR TITLE
feature 621 support ens.vld_thresh in EnsembleStat

### DIFF
--- a/docs/Users_Guide/glossary.rst
+++ b/docs/Users_Guide/glossary.rst
@@ -1292,6 +1292,13 @@ METplus Configuration Glossary
      | *Family:*  [config]
      | *Default:*  1.0
 
+   ENSEMBLE_STAT_ENS_VLD_THRESH
+     Threshold for the ratio of the number of valid data values to the total number of expected ensemble members. This value is passed into the ensemble_stat config file to make sure the percentage of files that are valid meets the expectation.
+
+     | *Used by:*  EnsembleStat
+     | *Family:*  [config]
+     | *Default:*  NONE
+
    ENSEMBLE_STAT_GRID_VX
      .. warning:: **DEPRECATED:** Please use :term:`ENSEMBLE_STAT_REGRID_TO_GRID`.
 

--- a/docs/Users_Guide/wrappers.rst
+++ b/docs/Users_Guide/wrappers.rst
@@ -155,6 +155,7 @@ Configuration
 | :term:`OBS_ENSEMBLE_STAT_FILE_WINDOW_BEGIN`
 | :term:`OBS_ENSEMBLE_STAT_FILE_WINDOW_END`
 | :term:`ENSEMBLE_STAT_ENS_THRESH`
+| :term:`ENSEMBLE_STAT_ENS_VLD_THRESH`
 | :term:`ENSEMBLE_STAT_CUSTOM_LOOP_LIST`
 | :term:`ENS_VAR<n>_NAME` (optional)
 | :term:`ENS_VAR<n>_LEVELS` (optional)

--- a/metplus/wrappers/ensemble_stat_wrapper.py
+++ b/metplus/wrappers/ensemble_stat_wrapper.py
@@ -145,6 +145,11 @@ class EnsembleStatWrapper(CompareGriddedWrapper):
 
         c_dict['REGRID_TO_GRID'] = self.config.getstr('config', 'ENSEMBLE_STAT_REGRID_TO_GRID', '')
 
+        self.set_c_dict_float(c_dict,
+                              'ENSEMBLE_STAT_ENS_VLD_THRESH',
+                              'vld_thresh',
+                              'ENS_VLD_THRESH')
+
         # used to override the file type for fcst/obs if using python embedding for input
         c_dict['ENS_FILE_TYPE'] = ''
         c_dict['FCST_FILE_TYPE'] = ''
@@ -342,6 +347,8 @@ class EnsembleStatWrapper(CompareGriddedWrapper):
         self.add_env_var("OBS_WINDOW_BEGIN", str(self.c_dict['OBS_WINDOW_BEGIN']))
         self.add_env_var("OBS_WINDOW_END", str(self.c_dict['OBS_WINDOW_END']))
         self.add_env_var("ENS_THRESH", self.c_dict['ENS_THRESH'])
+        self.add_env_var('ENS_VLD_THRESH',
+                         self.c_dict.get('ENS_VLD_THRESH', ''))
 
         self.add_env_var('OUTPUT_PREFIX', self.get_output_prefix(time_info))
 

--- a/parm/met_config/EnsembleStatConfig_wrapped
+++ b/parm/met_config/EnsembleStatConfig_wrapped
@@ -53,7 +53,7 @@ ens = {
    ${ENS_FILE_TYPE}
 
    ens_thresh = ${ENS_THRESH};
-   vld_thresh = 1.0;
+   ${ENS_VLD_THRESH}
 
    field = [ ${ENS_FIELD}  ];
 }

--- a/parm/use_cases/met_tool_wrapper/EnsembleStat/EnsembleStat.conf
+++ b/parm/use_cases/met_tool_wrapper/EnsembleStat/EnsembleStat.conf
@@ -61,6 +61,9 @@ ENSEMBLE_STAT_N_MEMBERS = 6
 # threshold for ratio of valid files to expected files to allow app to run
 ENSEMBLE_STAT_ENS_THRESH = 1.0
 
+# ens.vld_thresh value in the MET config file
+ENSEMBLE_STAT_ENS_VLD_THRESH = 1.0
+
 # Used in the MET config file for: regrid to_grid field
 ENSEMBLE_STAT_REGRID_TO_GRID = NONE
 

--- a/parm/use_cases/met_tool_wrapper/EnsembleStat/EnsembleStat_python_embedding.conf
+++ b/parm/use_cases/met_tool_wrapper/EnsembleStat/EnsembleStat_python_embedding.conf
@@ -52,6 +52,9 @@ ENSEMBLE_STAT_N_MEMBERS = 2
 # threshold for ratio of valid files to expected files to allow app to run
 ENSEMBLE_STAT_ENS_THRESH = 1.0
 
+# ens.vld_thresh value in the MET config file
+ENSEMBLE_STAT_ENS_VLD_THRESH = 1.0
+
 # Used in the MET config file for: regrid to_grid field
 ENSEMBLE_STAT_REGRID_TO_GRID = NONE
 


### PR DESCRIPTION
added support for setting ens.vld_thresh through the METplus configuration files

## Pull Request Testing ##

- [X] Describe testing already performed for these changes:</br>
I ran EnsembleStat.conf and EnsembleStat_python_embedding.conf use cases and verified that changing the METplus variable changes the value for the run.

- [X] Recommend testing for the reviewer to perform, including the location of input datasets:</br>
Add the METplus variable to your use case and verify that it is set correctly. If you are using an EnsembleStatConfig file other than the one in parm/met_config, you will have to add the environment variable to your config file. See the file in that directory for reference.

- [X] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [X] After merging, should the reviewer **DELETE** the feature branch from GitHub? **[Yes]**</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [X] Complete the PR definition above.
- [X] Ensure the PR title matches the feature or bugfix branch name.
- [X] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**, **Project(s)**, and **Milestone**
- [x] After submitting the PR, select **Linked Issues** with the original issue number.
