### PR TITLE
Feature 24 series lead plot

### DIFF
--- a/parm/use_cases/model_applications/medium_range/TCStat_SeriesAnalysis_fcstGFS_obsGFS_FeatureRelative_SeriesByLead.conf
+++ b/parm/use_cases/model_applications/medium_range/TCStat_SeriesAnalysis_fcstGFS_obsGFS_FeatureRelative_SeriesByLead.conf
@@ -76,7 +76,7 @@ TC_PAIRS_READ_ALL_FILES = no
 
 # List of models to be used (white space or comma separated) eg: DSHP, LGEM, HWRF
 # If no models are listed, then process all models in the input file(s).
-MODEL =
+MODEL = GFSO
 
 # List of storm ids of interest (space or comma separated) e.g.: AL112012, AL122012
 # If no storm ids are listed, then process all storm ids in the input file(s).


### PR DESCRIPTION
Closes #24 

## Pull Request Testing ##

- [X] Describe testing already performed for these changes:</br>
* Removed TOTAL from SERIES_ANALYSIS_STAT_LIST and verified that error occurs.
* Made modifications and reran to verify that image title now uses MODEL value (GFSO) and does not include (N = x)
* Added TOTAL back and reran to verify that (N = x) is properly shown when TOTAL is available

- [X] Recommend testing for the reviewer to perform, including the location of input datasets:</br>
* Review files on kiowa
  * Output from run without TOTAL is in /d1/personal/mccabe/out-lead-plot (latest log file is logs/master_metplus.log.20201119080834)
  * Output from run with TOTAL is in /d1/personal/mccabe/out-lead-plot-total
* Review images
  * Without TOTAL:
![series_F000_to_F018_TMP_Z2_FBAR_nototal](https://user-images.githubusercontent.com/23407799/99685649-0b40c600-2a40-11eb-9a2a-3f76feba0b59.png)
  * With TOTAL:
![series_F000_to_F018_TMP_Z2_FBAR_withtotal](https://user-images.githubusercontent.com/23407799/99686313-b5b8e900-2a40-11eb-99c5-eee731c8bfbb.png)
NOTE: Previously images had GFS hard-coded instead of GFSO. GFSO had to be used instead of GFS for MODEL because that config variable also controls filtering for TCPairs and the value of MODEL in the adeck/bdeck files is GFSO.

- [X] Will this PR result in changes to the test suite? **[No]**</br>

- [X] After merging, should the reviewer **DELETE** the feature branch from GitHub? **[Yes]**</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [X] Complete the PR definition above.
- [X] Ensure the PR title matches the feature or bugfix branch name.
- [X] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**, **Project(s)**, and **Milestone**
- [x] After submitting the PR, select **Linked Issues** with the original issue number.
