### PR TITLE
feature 704 multiple process instances

### DIFF
--- a/docs/Users_Guide/systemconfiguration.rst
+++ b/docs/Users_Guide/systemconfiguration.rst
@@ -356,6 +356,57 @@ will process valid times starting on 20190425 at 06Z every 6 hours until the cur
 
    When using the 'now' keyword, the value of VALID_TIME_FMT must be identical to the 'fmt' value corresponding to the 'now' item in VALID_BEG and VALID_END. In the above example, this would be the %Y%m%d%H portion within values of the VALID_TIME_FMT, VALID_BEG, and VALID_END variables.
 
+.. _Process_List:
+
+Process List
+~~~~~~~~~~~~
+
+################################################################################
+The PROCESS_LIST variable defines the list of wrappers to run.
+This can be a single value or a comma separated list of values.
+Each value must match an existing wrapper name without the 'Wrapper' suffix.
+
+**Example 1 Configuration**::
+
+    [config]
+    PROCESS_LIST = GridStat
+
+This example will run GridStatWrapper only.
+
+**Example 2 Configuration**::
+
+    [config]
+    PROCESS_LIST = PCPCombine, GridStat
+
+This example will run PCPCombineWrapper then GridStatWrapper.
+
+Added in version 4.0.0 is the ability to specify an instance name for each
+process in the PROCESS_LIST. This allows multiple instances of the same
+wrapper to be specified in the PROCESS_LIST. Users can create a new section
+header in their configuration files with the same name as the instance.
+If defined, values in this section will override the values in the
+configuration for that instance. The instance name of the process is defined
+by adding text after the process name inside parenthesis. There should be
+no space between the process name and the parenthesis.
+
+**Example 3 Configuration**::
+
+    [config]
+    PROCESS_LIST = GridStat, GridStat(my_instance_name)
+
+    [dir]
+    GRID_STAT_OUTPUT_DIR = /grid/stat/output/dir
+
+    [my_instance_name]
+    GRID_STAT_OUTPUT_DIR = /my/instance/name/output/dir
+
+In this example, the first occurence of GridStat in the PROCESS_LIST does
+not have an instance name associated with it, so it will use the value
+/grid/stat/output/dir as the output directory. The second occurence has
+an instance name 'my_instance_name' and there is a section header with
+the same name, so this instance will use /my/instance/name/output/dir as
+the output directory.
+
 .. _Loop_Order:
 
 Loop Order
@@ -363,7 +414,7 @@ Loop Order
 
 The METplus wrappers can be configured to loop first by times then processes or vice-versa. Looping by times first will run each process in the process list for a given run time, increment to the next run time, run each process in the process list, and so on. Looping by processes first will run all times for the first process, then run all times for the second process, and so on.
 
-Example 1 Configuration::
+**Example 1 Configuration**::
 
   [config]
   LOOP_ORDER = times
@@ -384,7 +435,7 @@ will run in the following order::
   * GridStat   at 2019-02-03
 
 
-Example 2 Configuration::
+**Example 2 Configuration**::
 
   [config]
   LOOP_ORDER = processes

--- a/internal_tests/pytests/command_builder/test_command_builder.py
+++ b/internal_tests/pytests/command_builder/test_command_builder.py
@@ -210,7 +210,7 @@ def test_find_obs_dated_next_day(metplus_config):
 def test_override_config_in_c_dict(metplus_config, overrides, c_dict):
     config = metplus_config()
 
-    pcw = CommandBuilder(config, overrides)
+    pcw = CommandBuilder(config, config_overrides=overrides)
     for key, expected_value in c_dict.items():
         assert(pcw.c_dict.get(key) == expected_value)
 
@@ -225,6 +225,6 @@ def test_override_config_in_c_dict(metplus_config, overrides, c_dict):
 def test_override_config(metplus_config, overrides):
     config = metplus_config()
 
-    pcw = CommandBuilder(config, overrides)
+    pcw = CommandBuilder(config, config_overrides=overrides)
     for key, expected_value in overrides.items():
         assert(pcw.config.getraw('config', key) == expected_value)

--- a/internal_tests/pytests/command_builder/test_command_builder.py
+++ b/internal_tests/pytests/command_builder/test_command_builder.py
@@ -11,28 +11,6 @@ import datetime
 from metplus.wrappers.command_builder import CommandBuilder
 from metplus.util import time_util
 
-# --------------------TEST CONFIGURATION and FIXTURE SUPPORT -------------
-#
-# The test configuration and fixture support the additional configuration
-# files used in METplus
-#              !!!!!!!!!!!!!!!
-#              !!!IMPORTANT!!!
-#              !!!!!!!!!!!!!!!
-# The following two methods should be included in ALL pytest tests for METplus.
-#
-#
-#def pytest_addoption(parser):
-#    parser.addoption("-c", action="store", help=" -c <test config file>")
-
-
-# @pytest.fixture
-#def cmdopt(request):
-#    return request.config.getoption("-c")
-
-
-# ------------------------ TESTS GO HERE --------------------------
-
-
 # ------------------------
 #  test_find_data_no_dated
 # ------------------------
@@ -227,4 +205,41 @@ def test_override_config(metplus_config, overrides):
 
     pcw = CommandBuilder(config, config_overrides=overrides)
     for key, expected_value in overrides.items():
+        assert(pcw.config.getraw('config', key) == expected_value)
+
+# dictionary items with values will be set in [test_section]
+# items with value None will not be set, so it should use
+# the value in [config], which is always 'default'
+@pytest.mark.parametrize(
+    'section_items', [
+        # all values set in test_section
+        ({'LOG_MET_VERBOSITY': '5',
+          'CUSTOM_LOOP_LIST': 'a,b,c',
+          'SKIP_TIMES': '"%H:12,18", "%Y%m%d:20200201"',
+          'FAKE_TEMPLATE': '{valid?fmt=%Y%m%d%H}' }),
+        # some values set in test_section, some not
+        ({'LOG_MET_VERBOSITY': '5',
+          'CUSTOM_LOOP_LIST': None,
+          'SKIP_TIMES': '"%H:12,18", "%Y%m%d:20200201"',
+          'FAKE_TEMPLATE': None }),
+        # no values are set in test_section
+        ({'FAKE_TEMPLATE': None}),
+        ]
+)
+def test_override_by_instance(metplus_config, section_items):
+    config = metplus_config()
+
+    # set config variables to default
+    for key in section_items:
+        config.set('config', key, 'default')
+
+    # set test_section variables to values
+    config.add_section('test_section')
+    for key, value in section_items.items():
+        if value is not None:
+            config.set('test_section', key, value)
+
+    pcw = CommandBuilder(config, instance='test_section')
+    for key, value in section_items.items():
+        expected_value = 'default' if value is None else value
         assert(pcw.config.getraw('config', key) == expected_value)

--- a/internal_tests/pytests/met_util/test_met_util.py
+++ b/internal_tests/pytests/met_util/test_met_util.py
@@ -687,25 +687,6 @@ def test_remove_staged_files():
     # unused files and directories remaining...
     shutil.rmtree(staged_dir)
 
-@pytest.mark.parametrize(
-    'process_list, has_plotter', [
-        (['PCPCombine'], False),
-        (['PCPCombine', 'GridStat'], False),
-        (['PCPCombine', 'RegridDataPlane', 'GridStat'], False),
-        (['CyclonePlotter'], True),
-        (['PCPCombine', 'CyclonePlotter', 'Other'], True),
-        (['MakePlots', 'Other'], True),
-        (['TCMPRPlotter'], True),
-        (['TCMPRPlotter', 'Other'], True),
-        (['Other', 'TCMPRPlotter'], True),
-        ([], False),
-        (['CyclonePlotter', 'TCMPRPlotter'], True),
-        (['CyclonePlotter', 'TCMPRPlotter', 'MakePlots'], True),
-    ]
-)
-def test_is_plotter_in_process_list(process_list, has_plotter):
-    assert(util.is_plotter_in_process_list(process_list) == has_plotter)
-
 # test that if wrapper specific field info is specified, it only gets
 # values from that list. All generic values should be read if no
 # wrapper specific field info variables are specified
@@ -746,43 +727,73 @@ def test_parse_var_list_wrapper_specific(metplus_config):
     'input_list, expected_list', [
         ('Point2Grid', ['Point2Grid']),
         # MET documentation syntax (with dashes)
-        ('Pcp-Combine, Grid-Stat, Ensemble-Stat', ['PCPCombine', 'GridStat', 'EnsembleStat']),
+        ('Pcp-Combine, Grid-Stat, Ensemble-Stat', ['PCPCombine',
+                                                   'GridStat',
+                                                   'EnsembleStat']),
         ('Point-Stat', ['PointStat']),
-        ('Mode, MODE Time Domain', ['MODE', 'MTD']),
+        ('Mode, MODE Time Domain', ['MODE',
+                                    'MTD']),
         # actual tool name (lower case underscore)
-        ('point_stat, grid_stat, ensemble_stat', ['PointStat', 'GridStat', 'EnsembleStat']),
-        ('mode, mtd', ['MODE', 'MTD']),
-        ('ascii2nc, pb2nc, regrid_data_plane', ['ASCII2NC', 'PB2NC', 'RegridDataPlane']),
-        ('pcp_combine, tc_pairs, tc_stat', ['PCPCombine', 'TCPairs', 'TCStat']),
-        ('gen_vx_mask, stat_analysis, series_analysis', ['GenVxMask', 'StatAnalysis', 'SeriesAnalysis']),
+        ('point_stat, grid_stat, ensemble_stat', ['PointStat',
+                                                  'GridStat',
+                                                  'EnsembleStat']),
+        ('mode, mtd', ['MODE',
+                       'MTD']),
+        ('ascii2nc, pb2nc, regrid_data_plane', ['ASCII2NC',
+                                                'PB2NC',
+                                                'RegridDataPlane']),
+        ('pcp_combine, tc_pairs, tc_stat', ['PCPCombine',
+                                            'TCPairs',
+                                            'TCStat']),
+        ('gen_vx_mask, stat_analysis, series_analysis', ['GenVxMask',
+                                                         'StatAnalysis',
+                                                         'SeriesAnalysis']),
         # old capitalization format
-        ('PcpCombine, Ascii2Nc, TcStat, TcPairs', ['PCPCombine', 'ASCII2NC', 'TCStat', 'TCPairs']),
-
+        ('PcpCombine, Ascii2Nc, TcStat, TcPairs', ['PCPCombine',
+                                                   'ASCII2NC',
+                                                   'TCStat',
+                                                   'TCPairs']),
+        # remove MakePlots from list
+        ('StatAnalysis, MakePlots', ['StatAnalysis']),
     ]
 )
 def test_get_process_list(metplus_config, input_list, expected_list):
     conf = metplus_config()
     conf.set('config', 'PROCESS_LIST', input_list)
-    output_list = util.get_process_list(conf)
+    process_list = util.get_process_list(conf)
+    output_list = [item[0] for item in process_list]
     assert(output_list == expected_list)
 
 @pytest.mark.parametrize(
-    'input_list, environ, expected_result', [
-        (['Point2Grid'], {}, True), # no plotters, not disabled
-        (['Point2Grid'], {'METPLUS_DISABLE_PLOT_WRAPPERS': 'yes'}, True), # no plotters, disabled
-        (['TCMPRPlotter'], {}, True), # plotter, not enabled
-        (['TCMPRPlotter'], {'METPLUS_DISABLE_PLOT_WRAPPERS': 'yes'}, False), # plotters, disabled
-        (['TCMPRPlotter'], {'METPLUS_ENABLE_PLOT_WRAPPERS': 'yes'}, True), # no plotters, enabled
-        # test that env var value is interpreted to be True or False instead of
-        # just checking if it is set to any value or not set
-        (['Point2Grid'], {'METPLUS_ENABLE_PLOT_WRAPPERS': 'no'}, True), # no plotters, disabled
-        (['Point2Grid'], {'METPLUS_DISABLE_PLOT_WRAPPERS': 'no'}, True), # no plotters, disabled
-        (['TCMPRPlotter'], {'METPLUS_ENABLE_PLOT_WRAPPERS': 'no'}, False), # no plotters, enabled no
-        (['TCMPRPlotter'], {'METPLUS_DISABLE_PLOT_WRAPPERS': 'no'}, True), # no plotters, disabled no
+    'input_list, expected_list', [
+        # no instances
+        ('Point2Grid', [('Point2Grid', None)]),
+        # one with instance one without
+        ('PcpCombine, GridStat(my_instance)', [('PCPCombine', None),
+                                               ('GridStat', 'my_instance')]),
+        # duplicate process, one with instance one without
+        ('TCStat, ExtractTiles, TCStat(for_series), SeriesAnalysis', (
+                [('TCStat',None),
+                 ('ExtractTiles',None),
+                 ('TCStat', 'for_series'),
+                 ('SeriesAnalysis',None),])),
+        # two processes, both with instances
+        ('mode(uno), mtd(dos)', [('MODE', 'uno'),
+                                 ('MTD', 'dos')]),
+        # lower-case names, first with instance, second without
+        ('ascii2nc(some_name), pb2nc', [('ASCII2NC', 'some_name'),
+                                        ('PB2NC', None)]),
+        # duplicate process, both with different instances
+        ('tc_stat(one), tc_pairs, tc_stat(two)', [('TCStat', 'one'),
+                                                  ('TCPairs', None),
+                                                  ('TCStat', 'two')]),
     ]
 )
-def test_check_plotter_in_process_list(input_list, environ, expected_result):
-    assert(util.check_plotter_in_process_list(input_list, environ) == expected_result)
+def test_get_process_list_instances(metplus_config, input_list, expected_list):
+    conf = metplus_config()
+    conf.set('config', 'PROCESS_LIST', input_list)
+    output_list = util.get_process_list(conf)
+    assert(output_list == expected_list)
 
 @pytest.mark.parametrize(
     'time_from_conf, fmt, is_datetime', [

--- a/internal_tests/pytests/plotting/make_plots/test_make_plots_wrapper.py
+++ b/internal_tests/pytests/plotting/make_plots/test_make_plots_wrapper.py
@@ -106,7 +106,6 @@ def test_create_c_dict(metplus_config):
     # Test 1
     c_dict = mp.create_c_dict()
     assert(c_dict['LOOP_ORDER'] == 'processes')
-    assert(c_dict['PROCESS_LIST'] == 'StatAnalysis, MakePlots')
     # NOTE: MakePlots relies on output from StatAnalysis
     #       so its input resides in the output of StatAnalysis
     assert(c_dict['INPUT_BASE_DIR'] == mp.config.getdir('OUTPUT_BASE')

--- a/internal_tests/pytests/stat_analysis/test_stat_analysis.py
+++ b/internal_tests/pytests/stat_analysis/test_stat_analysis.py
@@ -112,7 +112,6 @@ def test_create_c_dict(metplus_config):
     # Test 1
     c_dict = st.create_c_dict()
     assert(c_dict['LOOP_ORDER'] == 'times')
-    assert(c_dict['PROCESS_LIST'] == ['StatAnalysis'])
     assert(os.path.realpath(c_dict['CONFIG_FILE']) == (METPLUS_BASE+'/internal_tests/'
                                                        +'config/STATAnalysisConfig'))
     assert(c_dict['OUTPUT_BASE_DIR'] == (st.config.getdir('OUTPUT_BASE')

--- a/internal_tests/pytests/stat_analysis/test_stat_analysis_plotting.py
+++ b/internal_tests/pytests/stat_analysis/test_stat_analysis_plotting.py
@@ -111,7 +111,6 @@ def test_set_lists_as_loop_or_group(metplus_config):
 
     config_dict = {}
     config_dict['LOOP_ORDER'] = 'processes'
-    config_dict['PROCESS_LIST'] = 'StatAnalysis, MakePlots'
     config_dict['OUTPUT_BASE_DIR'] = 'OUTPUT_BASE/stat_analysis'
     config_dict['GROUP_LIST_ITEMS'] = ['FCST_INIT_HOUR_LIST']
     config_dict['LOOP_LIST_ITEMS'] = ['FCST_VALID_HOUR_LIST']

--- a/internal_tests/pytests/tc_stat/test_tc_stat_wrapper.py
+++ b/internal_tests/pytests/tc_stat/test_tc_stat_wrapper.py
@@ -131,7 +131,8 @@ def test_validate_config_values(metplus_config):
     ]
     )
 def test_override_config_in_c_dict(metplus_config, overrides, c_dict):
-    wrapper = TCStatWrapper(get_config(metplus_config), overrides)
+    wrapper = TCStatWrapper(get_config(metplus_config),
+                            config_overrides=overrides)
     for key, expected_value in c_dict.items():
         assert (wrapper.c_dict.get(key) == expected_value)
 

--- a/metplus/util/config_metplus.py
+++ b/metplus/util/config_metplus.py
@@ -509,15 +509,32 @@ def get_logger(config, sublog=None):
     config.logger = logger
     return logger
 
-def replace_config_from_section(config, section):
-    if not config.has_section(section):
-        error_message = f'Section {section} does not exist.'
-        if config.logger:
-            config.logger.error(error_message)
-        else:
-            print(f"ERROR: {error_message}")
+def replace_config_from_section(config, section, required=True):
+    """! Check if config has a section named [section] If it does, create a
+    new METplusConfig object, set each value from the input config, then
+    set each value from [section], overriding any values that are found in both
 
-        return None
+    @param config input METplusConfig object
+    @param section name of section in config object to look for
+    @param required (optional) True/False to determine if an error should occur
+    if the section does not exist. Default value is True
+    @returns If required and section does not exist, error and return None.
+    If not required and section does not exist, return input config. If section
+    does exist, return new METplusConfig object with config values replaced by
+    all values in [section]
+    """
+    if not config.has_section(section):
+        # if section is required to be found, report error and return None
+        if required:
+            error_message = f'Section {section} does not exist.'
+            if config.logger:
+                config.logger.error(error_message)
+            else:
+                print(f"ERROR: {error_message}")
+
+            return None
+        # if not required, return input config object
+        return config
 
     new_config = METplusConfig()
     all_configs = config.keys('config')

--- a/metplus/wrappers/ascii2nc_wrapper.py
+++ b/metplus/wrappers/ascii2nc_wrapper.py
@@ -24,11 +24,13 @@ from ..util import do_string_sub
 
 
 class ASCII2NCWrapper(CommandBuilder):
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = "ascii2nc"
         self.app_path = os.path.join(config.getdir('MET_BIN_DIR', ''),
                                      self.app_name)
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
     def create_c_dict(self):
         c_dict = super().create_c_dict()

--- a/metplus/wrappers/compare_gridded_wrapper.py
+++ b/metplus/wrappers/compare_gridded_wrapper.py
@@ -33,12 +33,14 @@ that reformat gridded data
     # types of climatology values that should be checked and set
     climo_types = ['MEAN', 'STDEV']
 
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         # set app_name if not set by child class to allow tests to run on this wrapper
         if not hasattr(self, 'app_name'):
             self.app_name = 'compare_gridded'
 
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
         # check to make sure all necessary probabilistic settings are set correctly
         # this relies on the subclass to finish creating the c_dict, so it has to
         # be checked after that happens

--- a/metplus/wrappers/cyclone_plotter_wrapper.py
+++ b/metplus/wrappers/cyclone_plotter_wrapper.py
@@ -34,11 +34,12 @@ class CyclonePlotterWrapper(CommandBuilder):
         Reads input from ATCF files generated from MET TC-Pairs
     """
 
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = 'cyclone_plotter'
 
-        # pylint:disable=redefined-outer-name
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
         if wrapper_cannot_run:
             self.log_error(f"There was a problem importing modules: {exception_err}\n")

--- a/metplus/wrappers/ensemble_stat_wrapper.py
+++ b/metplus/wrappers/ensemble_stat_wrapper.py
@@ -25,11 +25,13 @@ from ..util import do_string_sub
 class EnsembleStatWrapper(CompareGriddedWrapper):
     """!Wraps the MET tool ensemble_stat to compare ensemble datasets
     """
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = 'ensemble_stat'
         self.app_path = os.path.join(config.getdir('MET_BIN_DIR', ''),
                                      self.app_name)
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
     def create_c_dict(self):
         """!Create a dictionary containing the values set in the config file

--- a/metplus/wrappers/example_wrapper.py
+++ b/metplus/wrappers/example_wrapper.py
@@ -17,9 +17,11 @@ from . import CommandBuilder
 
 class ExampleWrapper(CommandBuilder):
     """!Wrapper can be used as a base to develop a new wrapper"""
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = 'example'
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
     def create_c_dict(self):
         c_dict = super().create_c_dict()

--- a/metplus/wrappers/extract_tiles_wrapper.py
+++ b/metplus/wrappers/extract_tiles_wrapper.py
@@ -23,9 +23,11 @@ class ExtractTilesWrapper(CommandBuilder):
          specified in the config file.
     """
 
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = 'extract_tiles'
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
         self.regrid_data_plane = self.regrid_data_plane_init()
 
     def create_c_dict(self):
@@ -125,7 +127,8 @@ class ExtractTilesWrapper(CommandBuilder):
 
         overrides[f'{rdp}_ONCE_PER_FIELD'] = False
         overrides[f'{rdp}_MANDATORY'] = False
-        rdp_wrapper = RegridDataPlaneWrapper(self.config, overrides)
+        rdp_wrapper = RegridDataPlaneWrapper(self.config,
+                                             config_overrides=overrides)
         rdp_wrapper.c_dict['SHOW_WARNINGS'] = False
         return rdp_wrapper
 

--- a/metplus/wrappers/gempak_to_cf_wrapper.py
+++ b/metplus/wrappers/gempak_to_cf_wrapper.py
@@ -24,10 +24,12 @@ from . import CommandBuilder
 
 
 class GempakToCFWrapper(CommandBuilder):
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = "GempakToCF"
         self.app_path = config.getstr('exe', 'GEMPAKTOCF_JAR', '')
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
     def create_c_dict(self):
         """!Create dictionary from config items to be used in the wrapper

--- a/metplus/wrappers/gen_vx_mask_wrapper.py
+++ b/metplus/wrappers/gen_vx_mask_wrapper.py
@@ -25,11 +25,13 @@ from ..util import do_string_sub
 
 class GenVxMaskWrapper(CommandBuilder):
 
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = "gen_vx_mask"
         self.app_path = os.path.join(config.getdir('MET_BIN_DIR', ''),
                                      self.app_name)
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
     def create_c_dict(self):
         c_dict = super().create_c_dict()

--- a/metplus/wrappers/grid_diag_wrapper.py
+++ b/metplus/wrappers/grid_diag_wrapper.py
@@ -24,11 +24,13 @@ from ..util import do_string_sub
 
 
 class GridDiagWrapper(CommandBuilder):
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = "grid_diag"
         self.app_path = os.path.join(config.getdir('MET_BIN_DIR'),
                                      self.app_name)
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
     def create_c_dict(self):
         c_dict = super().create_c_dict()

--- a/metplus/wrappers/grid_stat_wrapper.py
+++ b/metplus/wrappers/grid_stat_wrapper.py
@@ -24,11 +24,13 @@ from . import CompareGriddedWrapper
 class GridStatWrapper(CompareGriddedWrapper):
     '''!Wraps the MET tool grid_stat to compare gridded datasets
     '''
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = 'grid_stat'
         self.app_path = os.path.join(config.getdir('MET_BIN_DIR', ''),
                                      self.app_name)
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
     def create_c_dict(self):
         c_dict = super().create_c_dict()

--- a/metplus/wrappers/make_plots_wrapper.py
+++ b/metplus/wrappers/make_plots_wrapper.py
@@ -68,10 +68,12 @@ class MakePlotsWrapper(CommandBuilder):
         'VERIF_GRID', 'EVENT_EQUALIZATION', 'LOG_METPLUS', 'LOG_LEVEL'
     ]
 
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_path = 'python'
         self.app_name = 'make_plots'
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
         if wrapper_cannot_run:
             self.log_error(f"There was a problem importing modules: {exception_err}\n")
@@ -104,7 +106,6 @@ class MakePlotsWrapper(CommandBuilder):
                                c_dict['VERBOSITY'])
         )
         c_dict['LOOP_ORDER'] = self.config.getstr('config', 'LOOP_ORDER')
-        c_dict['PROCESS_LIST'] = self.config.getstr('config', 'PROCESS_LIST')
         c_dict['INPUT_BASE_DIR'] = self.config.getdir('MAKE_PLOTS_INPUT_DIR')
         c_dict['OUTPUT_BASE_DIR'] = self.config.getdir('MAKE_PLOTS_OUTPUT_DIR')
         c_dict['SCRIPTS_BASE_DIR'] = self.config.getdir('MAKE_PLOTS_SCRIPTS_DIR')

--- a/metplus/wrappers/mode_wrapper.py
+++ b/metplus/wrappers/mode_wrapper.py
@@ -18,13 +18,15 @@ from ..util import do_string_sub
 
 class MODEWrapper(CompareGriddedWrapper):
     """!Wrapper for the mode MET tool"""
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         # only set app variables if not already set by MTD (subclass)
         if not hasattr(self, 'app_name'):
             self.app_name = 'mode'
             self.app_path = os.path.join(config.getdir('MET_BIN_DIR', ''),
                                          self.app_name)
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
     def add_merge_config_file(self, time_info):
         """!If merge config file is defined, add it to the command"""

--- a/metplus/wrappers/mtd_wrapper.py
+++ b/metplus/wrappers/mtd_wrapper.py
@@ -20,11 +20,13 @@ from . import CompareGriddedWrapper
 
 class MTDWrapper(MODEWrapper):
 
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = 'mtd'
         self.app_path = os.path.join(config.getdir('MET_BIN_DIR', ''),
                                      self.app_name)
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
         self.fcst_file = None
         self.obs_file = None
 

--- a/metplus/wrappers/pb2nc_wrapper.py
+++ b/metplus/wrappers/pb2nc_wrapper.py
@@ -23,11 +23,13 @@ class PB2NCWrapper(CommandBuilder):
          to NetCDF for MET's point_stat tool can recognize.
     """
 
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = 'pb2nc'
         self.app_path = os.path.join(config.getdir('MET_BIN_DIR', ''),
                                      self.app_name)
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
     def create_c_dict(self):
         """! Create a data structure (dictionary) that contains all the

--- a/metplus/wrappers/pcp_combine_wrapper.py
+++ b/metplus/wrappers/pcp_combine_wrapper.py
@@ -34,11 +34,13 @@ class PCPCombineWrapper(ReformatGriddedWrapper):
     # valid values for [FCST/OBS]_PCP_COMBINE_METHOD
     valid_run_methods = ['ADD', 'SUM', 'SUBTRACT', 'DERIVE', 'USER_DEFINED']
 
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = 'pcp_combine'
         self.app_path = os.path.join(config.getdir('MET_BIN_DIR', ''),
                                      self.app_name)
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
         self.inaddons = []
         self.method = ""
         self.pcp_dir = ""

--- a/metplus/wrappers/plot_data_plane_wrapper.py
+++ b/metplus/wrappers/plot_data_plane_wrapper.py
@@ -24,11 +24,13 @@ from ..util import do_string_sub
 
 
 class PlotDataPlaneWrapper(CommandBuilder):
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = "plot_data_plane"
         self.app_path = os.path.join(config.getdir('MET_BIN_DIR', ''),
                                      self.app_name)
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
     def create_c_dict(self):
         c_dict = super().create_c_dict()

--- a/metplus/wrappers/point2grid_wrapper.py
+++ b/metplus/wrappers/point2grid_wrapper.py
@@ -25,11 +25,13 @@ from . import CommandBuilder
 
 class Point2GridWrapper(CommandBuilder):
 
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = "point2grid"
         self.app_path = os.path.join(config.getdir('MET_BIN_DIR', ''),
                                      self.app_name)
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
     def create_c_dict(self):
         c_dict = super().create_c_dict()

--- a/metplus/wrappers/point_stat_wrapper.py
+++ b/metplus/wrappers/point_stat_wrapper.py
@@ -20,11 +20,13 @@ from . import CompareGriddedWrapper
 class PointStatWrapper(CompareGriddedWrapper):
     """! Wrapper to the MET tool, Point-Stat."""
 
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = 'point_stat'
         self.app_path = os.path.join(config.getdir('MET_BIN_DIR', ''),
                                      self.app_name)
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
     def create_c_dict(self):
         """! Create a dictionary that holds all the values set in the

--- a/metplus/wrappers/py_embed_ingest_wrapper.py
+++ b/metplus/wrappers/py_embed_ingest_wrapper.py
@@ -24,9 +24,11 @@ VALID_PYTHON_EMBED_TYPES = ['NUMPY', 'XARRAY', 'PANDAS']
 class PyEmbedIngestWrapper(CommandBuilder):
     """!Wrapper to utilize Python Embedding in the MET tools to read in
     data using a python script"""
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = 'py_embed_ingest'
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
     def create_c_dict(self):
         c_dict = super().create_c_dict()

--- a/metplus/wrappers/reformat_gridded_wrapper.py
+++ b/metplus/wrappers/reformat_gridded_wrapper.py
@@ -30,8 +30,10 @@ class ReformatGriddedWrapper(CommandBuilder):
     """!Common functionality to wrap similar MET applications
 that reformat gridded data
     """
-    def __init__(self, config, config_overrides={}):
-        super().__init__(config, config_overrides)
+    def __init__(self, config, instance=None, config_overrides={}):
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
     # this class should not be called directly
     # pylint:disable=unused-argument

--- a/metplus/wrappers/regrid_data_plane_wrapper.py
+++ b/metplus/wrappers/regrid_data_plane_wrapper.py
@@ -25,11 +25,13 @@ from . import ReformatGriddedWrapper
 class RegridDataPlaneWrapper(ReformatGriddedWrapper):
     '''!Wraps the MET tool regrid_data_plane to reformat gridded datasets
     '''
-    def __init__(self, config, config_overrides={}):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = 'regrid_data_plane'
         self.app_path = os.path.join(config.getdir('MET_BIN_DIR', ''),
                                      self.app_name)
-        super().__init__(config, config_overrides)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
     def create_c_dict(self):
         c_dict = super().create_c_dict()

--- a/metplus/wrappers/series_analysis_wrapper.py
+++ b/metplus/wrappers/series_analysis_wrapper.py
@@ -24,11 +24,13 @@ from ..util import do_string_sub
 '''
 
 class SeriesAnalysisWrapper(CompareGriddedWrapper):
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = "series_analysis"
         self.app_path = os.path.join(config.getdir('MET_BIN_DIR', ''),
                                      self.app_name)
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
     def create_c_dict(self):
         c_dict = super().create_c_dict()

--- a/metplus/wrappers/series_by_init_wrapper.py
+++ b/metplus/wrappers/series_by_init_wrapper.py
@@ -29,11 +29,13 @@ class SeriesByInitWrapper(CommandBuilder):
           series_analysis is done
     """
 
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_path = os.path.join(config.getdir('MET_BIN_DIR', ''),
                                      'series_analysis')
         self.app_name = os.path.basename(self.app_path)
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
         # Retrieve any necessary values (dirs, executables)
         # from the param file(s)
         self.stat_list = util.getlist(self.config.getstr('config', 'SERIES_ANALYSIS_STAT_LIST'))
@@ -253,7 +255,8 @@ class SeriesByInitWrapper(CommandBuilder):
                              'TC_STAT_OUTPUT_DIR': series_output_dir,
                              'TC_STAT_MATCH_POINTS': True,
                              }
-            tc_stat_wrapper = TCStatWrapper(self.config, override_dict)
+            tc_stat_wrapper = TCStatWrapper(self.config,
+                                            config_overrides=override_dict)
             if not tc_stat_wrapper.isOK:
                 self.log_error('TCStat wrapper did not initialize properly')
                 continue

--- a/metplus/wrappers/series_by_lead_wrapper.py
+++ b/metplus/wrappers/series_by_lead_wrapper.py
@@ -34,9 +34,11 @@ class SeriesByLeadWrapper(CommandBuilder):
          file.
     """
 
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = 'series_analysis'
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
         # Retrieve any necessary values from the parm file(s)
         self.do_fhr_by_group = self.config.getbool('config',
                                                    'SERIES_ANALYSIS_GROUP_FCSTS')
@@ -1331,7 +1333,8 @@ class SeriesByLeadWrapper(CommandBuilder):
                              'TC_STAT_OUTPUT_DIR': series_output_dir,
                              'TC_STAT_MATCH_POINTS': True,
                              }
-            tc_stat_wrapper = TCStatWrapper(self.config, override_dict)
+            tc_stat_wrapper = TCStatWrapper(self.config,
+                                            config_overrides=override_dict)
             if not tc_stat_wrapper.isOK:
                 continue
 

--- a/metplus/wrappers/stat_analysis_wrapper.py
+++ b/metplus/wrappers/stat_analysis_wrapper.py
@@ -75,11 +75,13 @@ class StatAnalysisWrapper(CommandBuilder):
         'FCST_INIT_HOUR_LIST', 'OBS_INIT_HOUR_LIST'
     ]
 
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_path = os.path.join(config.getdir('MET_BIN_DIR', ''),
                                      'stat_analysis')
         self.app_name = os.path.basename(self.app_path)
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
     def get_command(self):
 
@@ -122,7 +124,6 @@ class StatAnalysisWrapper(CommandBuilder):
                                c_dict['VERBOSITY'])
         )
         c_dict['LOOP_ORDER'] = self.config.getstr('config', 'LOOP_ORDER')
-        c_dict['PROCESS_LIST'] = util.get_process_list(self.config)
         c_dict['CONFIG_FILE'] = self.config.getstr('config', 
                                                    'STAT_ANALYSIS_CONFIG_FILE',
                                                    '')

--- a/metplus/wrappers/tc_gen_wrapper.py
+++ b/metplus/wrappers/tc_gen_wrapper.py
@@ -26,11 +26,13 @@ from ..util import do_string_sub
 
 
 class TCGenWrapper(CommandBuilder):
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = "tc_gen"
         self.app_path = os.path.join(config.getdir('MET_BIN_DIR'),
                                      self.app_name)
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
     def create_c_dict(self):
         c_dict = super().create_c_dict()

--- a/metplus/wrappers/tc_pairs_wrapper.py
+++ b/metplus/wrappers/tc_pairs_wrapper.py
@@ -40,11 +40,13 @@ class TCPairsWrapper(CommandBuilder):
        bdeck files.  Pre-processes extra tropical cyclone data.
     """
 
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = 'tc_pairs'
         self.app_path = os.path.join(config.getdir('MET_BIN_DIR', ''),
                                      self.app_name)
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
         self.adeck = []
         self.bdeck = []
         self.edeck = []

--- a/metplus/wrappers/tc_stat_wrapper.py
+++ b/metplus/wrappers/tc_stat_wrapper.py
@@ -36,12 +36,14 @@ class TCStatWrapper(CommandBuilder):
          cyclone pair data.
     """
 
-    def __init__(self, config, config_overrides={}):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = 'tc_stat'
         self.app_path = os.path.join(config.getdir('MET_BIN_DIR', ''),
                                      self.app_name)
 
-        super().__init__(config, config_overrides)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
         self.logger.debug("Initialized TCStatWrapper")
 
     def create_c_dict(self):

--- a/metplus/wrappers/tcmpr_plotter_wrapper.py
+++ b/metplus/wrappers/tcmpr_plotter_wrapper.py
@@ -38,7 +38,7 @@ class TCMPRPlotterWrapper(CommandBuilder):
     indicate a file or directory in the (required) -lookin option.
     """
 
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         """!Constructor for TCMPRPlotterWrapper
             Args:
             @param p:  The configuration instance, contains
@@ -51,7 +51,9 @@ class TCMPRPlotterWrapper(CommandBuilder):
         # pylint:disable=too-many-instance-attributes
         # All these instance attributes are needed to support the
         # plot_tcmpr.R functionality.
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
         # check if R is available, do not attempt to run if it is not
         if shutil.which('Rscript') is None:

--- a/metplus/wrappers/tcrmw_wrapper.py
+++ b/metplus/wrappers/tcrmw_wrapper.py
@@ -24,11 +24,13 @@ from ..util import do_string_sub
 
 
 class TCRMWWrapper(CommandBuilder):
-    def __init__(self, config):
+    def __init__(self, config, instance=None, config_overrides={}):
         self.app_name = "tc_rmw"
         self.app_path = os.path.join(config.getdir('MET_BIN_DIR'),
                                      self.app_name)
-        super().__init__(config)
+        super().__init__(config,
+                         instance=instance,
+                         config_overrides=config_overrides)
 
     def create_c_dict(self):
         c_dict = super().create_c_dict()


### PR DESCRIPTION
Note: I did not add a use case to the repository to demonstrate this functionality. This work is needed for #670 / #671 refactor of SeriesByInit/Lead. The use cases that run these tools will eventually be modified to call TCStat multiple times, which will demonstrate this new logic. If you think we should add a simple met_tool_wrapper use case to demonstrate this, please let me know.

## Pull Request Testing ##

- [X] Describe testing already performed for these changes:</br>
Ran unit tests that check that config variables are overridden properly

- [X] Recommend testing for the reviewer to perform, including the location of input datasets:</br>
* Run use case on kiowa to test that config variables are overridden properly:
/d1/projects/METplus/METplus_pull_requests/METplus-4.0-beta2/feature_704/GridStat_multi.conf
This use case should run GridStat twice, writing to 2 different output directories
* Review new additions to documentation to ensure they make sense
* (Optional) Test changes to example use case to verify that it works as intended

- [X] Will this PR result in changes to the test suite? **[No]**</br>

- [X] After merging, should the reviewer **DELETE** the feature branch from GitHub? **[Yes]**</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [X] Complete the PR definition above.
- [X] Ensure the PR title matches the feature or bugfix branch name.
- [X] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**, **Project(s)**, and **Milestone**
- [x] After submitting the PR, select **Linked Issues** with the original issue number.
