### PR TITLE
bugfix 730 main_v3.1 time_info corrupted

### DIFF
--- a/metplus/util/time_util.py
+++ b/metplus/util/time_util.py
@@ -182,8 +182,10 @@ def ti_get_lead_string(lead, plural=True):
 
     return output
 
-def ti_calculate(input_dict):
+def ti_calculate(input_dict_preserve):
     out_dict = {}
+    # copy input dictionary to avoid corrupting it
+    input_dict = input_dict_preserve.copy()
 
     # set output dictionary to input items
     if 'now' in input_dict.keys():


### PR DESCRIPTION
The bug occurs when a time_info dictionary is passed back into time_util.ti_calculate. The function checks if init and valid are both set in the input dictionary. If so, it uses the loop_by value to determine which of them to delete from the dictionary so it will be recomputed. The call to del on the input dictionary deleted the 'valid' item from the input dictionary which is still used elsewhere in the code.

To fix in v3.1, copy input to ti_calculate into a new dictionary so that it can't be corrupted

## Pull Request Testing ##

- [X] Describe testing already performed for these changes:</br>
* Ran the use case using main_v3.1 and confirmed a TypeError and crash occur:
`/d1/projects/METplus/METplus_Development/bugfix_time_info/METplus.main_v3.1/ush/master_metplus.py -c /d1/projects/METplus/METplus_Development/bugfix_time_info/metplus_final.conf`
* Ran the case again using the fixed version to verify that although there are errors (data is not available), the case runs to completion.
`/d1/projects/METplus/METplus_Development/bugfix_time_info/METplus.main_v3.1_fix/ush/master_metplus.py -c /d1/projects/METplus/METplus_Development/bugfix_time_info/metplus_final.conf`
- [X] Recommend testing for the reviewer to perform, including the location of input datasets:</br>
* Review the output on kiowa or rerun to verify that the change fixes the crash.

- [X] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [X] After merging, should the reviewer **DELETE** the feature branch from GitHub? **[Yes]**</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [X] Complete the PR definition above.
- [X] Ensure the PR title matches the feature or bugfix branch name.
- [X] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**, **Project(s)**, and **Milestone**
- [x] After submitting the PR, select **Linked Issues** with the original issue number.
