### PR TITLE
feature 707 semicolon in var options

### DIFF
--- a/internal_tests/pytests/met_util/test_met_util.py
+++ b/internal_tests/pytests/met_util/test_met_util.py
@@ -1136,3 +1136,36 @@ def test_get_storms(metplus_config, filename, expected_result):
     # ensure header matches expected format
     if storm_dict:
         assert(storm_dict['header'].split()[storm_id_index] == 'STORM_ID')
+
+@pytest.mark.parametrize(
+    'config_overrides, expected_result', [
+        # 2 items semi-colon at end
+        ({'FCST_VAR1_OPTIONS': 'GRIB_lvl_typ = 234;  desc = "HI_CLOUD";',},
+         'GRIB_lvl_typ = 234; desc = "HI_CLOUD";'),
+        # 2 items no semi-colon at end
+        ({'FCST_VAR1_OPTIONS': 'GRIB_lvl_typ = 234;  desc = "HI_CLOUD"',},
+         'GRIB_lvl_typ = 234; desc = "HI_CLOUD";'),
+        # 1 item semi-colon at end
+        ({'FCST_VAR1_OPTIONS': 'GRIB_lvl_typ = 234;',
+          },
+         'GRIB_lvl_typ = 234;'),
+        # 1 item no semi-colon at end
+        ({'FCST_VAR1_OPTIONS': 'GRIB_lvl_typ = 234',
+          },
+         'GRIB_lvl_typ = 234;'),
+    ]
+)
+def test_get_var_items_options_semicolon(metplus_config, config_overrides,
+                                         expected_result):
+    config = metplus_config()
+    config.set('config', 'FCST_VAR1_NAME', 'FNAME')
+    config.set('config', 'FCST_VAR1_LEVELS', 'FLEVEL')
+    for key, value in config_overrides.items():
+        config.set('config', key, value)
+
+    data_type = 'FCST'
+    index = 1
+    time_info = {}
+
+    _, _, _, result = util.get_var_items(config, data_type, index, time_info)
+    assert(result == expected_result)

--- a/metplus/util/met_util.py
+++ b/metplus/util/met_util.py
@@ -2178,10 +2178,14 @@ def get_var_items(config, data_type, index, time_info, met_tool=None):
         extra = do_string_sub(config.getraw('config', search_extra),
                               **time_info)
 
-        # split up each item by semicolon, then add a semicolon to the end of each item
+        # strip off empty space around each value
+        extra_list = [item.strip() for item in extra.split(';')]
+
+        # split up each item by semicolon, then add a semicolon to the
+        # end of each item
         # to avoid errors where the user forgot to add a semicolon at the end
         # use list(filter(None to remove empty strings from list
-        extra_list = list(filter(None, extra.split(';')))
+        extra_list = list(filter(None, extra_list))
         extra = f"{'; '.join(extra_list)};"
 
     return name, levels, thresh, extra


### PR DESCRIPTION
It turns out the logic for this was already implemented. Added logic to strip off whitespace around each option, added test to confirm semi-colon is added to end of options

## Pull Request Testing ##

- [X] Describe testing already performed for these changes:</br>

Pytests run succesfully

- [X] Recommend testing for the reviewer to perform, including the location of input datasets:</br>

Ensure all tests succeed in GitHub Actions:
https://github.com/dtcenter/METplus/actions/runs/496577284

- [X] Will this PR result in changes to the test suite? **[No]**</br>
New test was added but it should succeed

- [X] After merging, should the reviewer **DELETE** the feature branch from GitHub? **[Yes]**</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [X] Complete the PR definition above.
- [X] Ensure the PR title matches the feature or bugfix branch name.
- [X] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**, **Project(s)**, and **Milestone**
- [x] After submitting the PR, select **Linked Issues** with the original issue number.
