### PR TITLE
feature 777 fix flaw in new behavior

### DIFF
--- a/internal_tests/pytests/config/config_1.conf
+++ b/internal_tests/pytests/config/config_1.conf
@@ -1,0 +1,4 @@
+[config]
+
+VAR_TO_TEST_A = A1
+VAR_TO_TEST_1 = 1

--- a/internal_tests/pytests/config/config_2.conf
+++ b/internal_tests/pytests/config/config_2.conf
@@ -1,0 +1,4 @@
+[dir]
+
+VAR_TO_TEST_A = A2
+VAR_TO_TEST_2 = 2

--- a/internal_tests/pytests/config/config_3.conf
+++ b/internal_tests/pytests/config/config_3.conf
@@ -1,0 +1,4 @@
+[config]
+
+VAR_TO_TEST_A = A3
+VAR_TO_TEST_3 = 3

--- a/internal_tests/pytests/config/test_config.py
+++ b/internal_tests/pytests/config/test_config.py
@@ -220,3 +220,19 @@ def test_getint(metplus_config, input_value, default, result):
         if result is None:
             assert(True)
 
+@pytest.mark.parametrize(
+    'config_key, expected_result', [
+        ('VAR_TO_TEST_1', '1'),
+        ('VAR_TO_TEST_2', '2'),
+        ('VAR_TO_TEST_3', '3'),
+        # should use last instance in config_3.conf
+        ('VAR_TO_TEST_A', 'A3'),
+    ]
+)
+def test_move_all_to_config_section(metplus_config, config_key, expected_result):
+    config_files = ['config_1.conf',
+                    'config_2.conf',
+                    'config_3.conf',
+                   ]
+    config = metplus_config(config_files)
+    assert(config.getstr('config', config_key) == expected_result)

--- a/internal_tests/pytests/config/test_config.py
+++ b/internal_tests/pytests/config/test_config.py
@@ -234,6 +234,8 @@ def test_move_all_to_config_section(metplus_config, config_key, expected_result)
                     'config_2.conf',
                     'config_3.conf',
                    ]
+    test_dir = os.path.dirname(__file__)
+    config_files = [os.path.join(test_dir, item) for item in config_files]
     config = metplus_config(config_files)
     assert(config.getstr('config', config_key) == expected_result)
 

--- a/internal_tests/pytests/config/test_config.py
+++ b/internal_tests/pytests/config/test_config.py
@@ -236,3 +236,35 @@ def test_move_all_to_config_section(metplus_config, config_key, expected_result)
                    ]
     config = metplus_config(config_files)
     assert(config.getstr('config', config_key) == expected_result)
+
+@pytest.mark.parametrize(
+    'overrides, config_key, expected_result', [
+        (['config.CMD_LINE_1=1',
+          ],
+        'CMD_LINE_1', '1'),
+        (['dir.CMD_LINE_1=1',
+          ],
+        'CMD_LINE_1', '1'),
+        (['filename_templates.CMD_LINE_1=1',
+          ],
+        'CMD_LINE_1', '1'),
+        (['user_env_vars.CMD_LINE_1=1',
+          ],
+        'CMD_LINE_1', ''),
+        (['made_up.CMD_LINE_1=1',
+          ],
+        'CMD_LINE_1', ''),
+        (['config.CMD_LINE_1=1',
+          'dir.CMD_LINE_1=2',
+          ],
+        'CMD_LINE_1', '2'),
+        (['dir.CMD_LINE_1=1',
+          'config.CMD_LINE_1=2',
+          ],
+        'CMD_LINE_1', '2'),
+    ]
+)
+def test_move_all_to_config_section_cmd_line(metplus_config, overrides,
+                                             config_key, expected_result):
+    config = metplus_config(overrides)
+    assert(config.getstr('config', config_key, '') == expected_result)

--- a/metplus/util/config_metplus.py
+++ b/metplus/util/config_metplus.py
@@ -248,6 +248,9 @@ def launch(file_list, moreopt):
         config.read(filename)
         logger.info("%s: Parsed this file" % (filename,))
 
+        # move all config variables from old sections into the [config] section
+        config.move_all_to_config_section()
+
     # Overriding or passing in specific conf items on the command line
     # ie. config.NEWVAR="a new var" dir.SOMEDIR=/override/dir/path
     # If spaces, seems like you need double quotes on command line.
@@ -260,7 +263,7 @@ def launch(file_list, moreopt):
                             % (section, option, repr(value)))
                 config.set(section, option, value)
 
-    # after all of the config files and overrides have been read in
+    # after all of the overrides have been read in
     # move all config variables from old sections into the [config] section
     config.move_all_to_config_section()
 

--- a/metplus/util/config_metplus.py
+++ b/metplus/util/config_metplus.py
@@ -263,9 +263,9 @@ def launch(file_list, moreopt):
                             % (section, option, repr(value)))
                 config.set(section, option, value)
 
-    # after all of the overrides have been read in
-    # move all config variables from old sections into the [config] section
-    config.move_all_to_config_section()
+                # after each config variable override,
+                # move old sections to [config]
+                config.move_all_to_config_section()
 
     # get OUTPUT_BASE to make sure it is set correctly so the first error
     # that is logged relates to OUTPUT_BASE, not LOG_DIR, which is likely


### PR DESCRIPTION
I discovered a flaw in the design of the new functionality. If a value is found first in an old section, i.e. [dir], then later found in the [config] section, the last value should be used. In the current implementation, the last (from [config]) value is set, then the values from [dir] are copied into [config] which overwrites the value that should be used.

Fixed bug in config setup by moving all config variables from old sections to [config] section after each config file that is read. Variables also needed to be moved after each command line override as well to ensure that the last value is used. I added tests to confirm expected result occurs.

## Pull Request Testing ##

- [X] Describe testing already performed for these changes:</br>
- 
Added unit tests that failed before changes, then ensured that tests passed with the new changes.

- [X] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

Review code changes

- [X] Do these changes include sufficient documentation and testing updates? **[Yes]**

- [X] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [X] Complete the PR definition above.
- [X] Ensure the PR title matches the feature or bugfix branch name.
- [X] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**, **Project(s)**, and **Milestone**
- [x] After submitting the PR, select **Linked Issues** with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
