### PR TITLE
fix broken automation logic

### DIFF
--- a/ci/actions/run_tests/Dockerfile
+++ b/ci/actions/run_tests/Dockerfile
@@ -3,6 +3,6 @@ FROM alpine:latest
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-RUN apk add --update --no-cache docker python3 py3-pip
+RUN apk add --update --no-cache docker python3 py3-pip bash
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/ci/jobs/docker_setup.sh
+++ b/ci/jobs/docker_setup.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 branch_name=`${GITHUB_WORKSPACE}/ci/jobs/print_branch_name.py`
 if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then

--- a/ci/jobs/get_artifact_name.sh
+++ b/ci/jobs/get_artifact_name.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 artifact_name=$1
 artifact_name=`echo $artifact_name | tr , _`


### PR DESCRIPTION
## Pull Request Testing ##

I discovered that some logic in the automation scripts broken in recent changes. The lightweight Docker image (alpine) does not have bash by default. A recent fix changed a few of the scripts run in automation to use #!/bin/sh instead of #!/bin/bash. This broke the if statements in those scripts. /bin/sh can vary what is actually used behind the scenes, so it seems safer to just install bash in the lightweight Docker image and change the scripts back to using bash to ensure that we know that we will get the correct behavior in our scripting.

- [X] Describe testing already performed for these changes:</br>
Reviewed automation logs and verified that errors are no longer occurring.

- [X] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
Review the automation logs:
Broken (develop): https://github.com/dtcenter/METplus/runs/1963614672?check_suite_focus=true#step:4:9
Fixed: https://github.com/dtcenter/METplus/runs/1963655821?check_suite_focus=true#step:4:9

- [X] Do these changes include sufficient documentation and testing updates? **[Yes]**

- [X] Will this PR result in changes to the test suite? **[Yes]**</br>
It will fix it!

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [X] Complete the PR definition above.
- [X] Ensure the PR title matches the feature or bugfix branch name.
- [X] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**, **Project(s)**, and **Milestone**
- [X] After submitting the PR, select **Linked Issues** with the original issue number. - no issue
- [x] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [x] Close the linked issue and delete your feature or bugfix branch from GitHub.
