### PR TITLE
bugfix 914 handle complex _VAR<n>_OPTIONS like MET dictionaries

### DIFF
--- a/internal_tests/pytests/point_stat/test_point_stat_wrapper.py
+++ b/internal_tests/pytests/point_stat/test_point_stat_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import pytest

--- a/internal_tests/pytests/point_stat/test_point_stat_wrapper.py
+++ b/internal_tests/pytests/point_stat/test_point_stat_wrapper.py
@@ -5,12 +5,50 @@ import pytest
 
 from metplus.wrappers.point_stat_wrapper import PointStatWrapper
 
+fcst_dir = '/some/path/fcst'
+obs_dir = '/some/path/obs'
 
-def point_stat_wrapper(metplus_config):
-    """! Returns a default PointStatWrapper """
+def set_minimum_config_settings(config):
+    # set config variables to prevent command from running and bypass check
+    # if input files actually exist
+    config.set('config', 'DO_NOT_RUN_EXE', True)
+    config.set('config', 'INPUT_MUST_EXIST', False)
 
+    # set process and time config variables
+    config.set('config', 'PROCESS_LIST', 'PointStat')
+    config.set('config', 'LOOP_BY', 'INIT')
+    config.set('config', 'INIT_TIME_FMT', '%Y%m%d%H')
+    config.set('config', 'INIT_BEG', '2005080700')
+    config.set('config', 'INIT_END', '2005080712')
+    config.set('config', 'INIT_INCREMENT', '12H')
+    config.set('config', 'LEAD_SEQ', '12H')
+    config.set('config', 'LOOP_ORDER', 'times')
+
+    config.set('config', 'POINT_STAT_CONFIG_FILE',
+               '{PARM_BASE}/met_config/PointStatConfig_wrapped')
+    config.set('config', 'FCST_POINT_STAT_INPUT_DIR', fcst_dir)
+    config.set('config', 'OBS_POINT_STAT_INPUT_DIR', obs_dir)
+    config.set('config', 'FCST_POINT_STAT_INPUT_TEMPLATE',
+               '{init?fmt=%Y%m%d%H}/fcst_file_F{lead?fmt=%3H}')
+    config.set('config', 'OBS_POINT_STAT_INPUT_TEMPLATE',
+               '{valid?fmt=%Y%m%d%H}/obs_file')
+    config.set('config', 'POINT_STAT_OUTPUT_DIR',
+               '{OUTPUT_BASE}/GridStat/output')
+    config.set('config', 'POINT_STAT_OUTPUT_TEMPLATE', '{valid?fmt=%Y%m%d%H}')
+
+def test_met_dictionary_in_var_options(metplus_config):
     config = metplus_config()
-    return PointStatWrapper(config)
+    set_minimum_config_settings(config)
+
+    config.set('config', 'BOTH_VAR1_NAME', 'name')
+    config.set('config', 'BOTH_VAR1_LEVELS', 'level')
+    config.set('config', 'BOTH_VAR1_OPTIONS',
+               'interp = { type = [ { method = NEAREST; width = 1; } ] };')
+
+    wrapper = PointStatWrapper(config)
+    assert(wrapper.isOK)
+
+    all_cmds = wrapper.run_all_times()
 
 @pytest.mark.parametrize(
     'config_overrides, env_var_values', [
@@ -372,9 +410,6 @@ def test_point_stat_all_fields(metplus_config, config_overrides,
     level_no_quotes = '(*,*)'
     level_with_quotes = f'"{level_no_quotes}"'
 
-    fcst_dir = '/some/path/fcst'
-    obs_dir = '/some/path/obs'
-
     fcsts = [{'name': 'TMP',
               'level': 'P750-900',
               'thresh': '<=273,>273'},
@@ -413,35 +448,8 @@ def test_point_stat_all_fields(metplus_config, config_overrides,
         fcst_fmts.append(fcst_fmt)
         obs_fmts.append(obs_fmt)
 
-
     config = metplus_config()
-
-    # set config variables to prevent command from running and bypass check
-    # if input files actually exist
-    config.set('config', 'DO_NOT_RUN_EXE', True)
-    config.set('config', 'INPUT_MUST_EXIST', False)
-
-    # set process and time config variables
-    config.set('config', 'PROCESS_LIST', 'PointStat')
-    config.set('config', 'LOOP_BY', 'INIT')
-    config.set('config', 'INIT_TIME_FMT', '%Y%m%d%H')
-    config.set('config', 'INIT_BEG', '2005080700')
-    config.set('config', 'INIT_END', '2005080712')
-    config.set('config', 'INIT_INCREMENT', '12H')
-    config.set('config', 'LEAD_SEQ', '12H')
-    config.set('config', 'LOOP_ORDER', 'times')
-
-    config.set('config', 'POINT_STAT_CONFIG_FILE',
-               '{PARM_BASE}/met_config/PointStatConfig_wrapped')
-    config.set('config', 'FCST_POINT_STAT_INPUT_DIR', fcst_dir)
-    config.set('config', 'OBS_POINT_STAT_INPUT_DIR', obs_dir)
-    config.set('config', 'FCST_POINT_STAT_INPUT_TEMPLATE',
-               '{init?fmt=%Y%m%d%H}/fcst_file_F{lead?fmt=%3H}')
-    config.set('config', 'OBS_POINT_STAT_INPUT_TEMPLATE',
-               '{valid?fmt=%Y%m%d%H}/obs_file')
-    config.set('config', 'POINT_STAT_OUTPUT_DIR',
-               '{OUTPUT_BASE}/GridStat/output')
-    config.set('config', 'POINT_STAT_OUTPUT_TEMPLATE', '{valid?fmt=%Y%m%d%H}')
+    set_minimum_config_settings(config)
 
     for index, (fcst, obs) in enumerate(zip(fcsts, obss)):
         idx = index + 1
@@ -499,4 +507,3 @@ def test_point_stat_all_fields(metplus_config, config_overrides,
                 assert (value == obs_fmt)
             else:
                 assert(env_var_values.get(env_var_key, '') == value)
-

--- a/metplus/util/met_util.py
+++ b/metplus/util/met_util.py
@@ -2436,9 +2436,12 @@ def sub_var_info(var_info, time_info):
         if isinstance(value, list):
             out_value = []
             for item in value:
-                out_value.append(do_string_sub(item, **time_info))
+                out_value.append(do_string_sub(item,
+                                               skip_missing_tags=True,
+                                               **time_info))
         else:
             out_value = do_string_sub(value,
+                                      skip_missing_tags=True,
                                       **time_info)
 
         out_var_info[key] = out_value


### PR DESCRIPTION
Change involves allowing missing tags in string template substitution for parsing field options and adding unit tests to test logic. I confirmed the test caused a crash before making the fix.

## Pull Request Testing ##

- [X] Describe testing already performed for these changes:</br>
Added unit test (see above)

- [X] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

Ensure all automated checks pass without any failures

- [X] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**

None needed

- [X] Do these changes include sufficient testing updates? **[Yes]**

- [X] Will this PR result in changes to the test suite? **[No]**</br>

- [X] Please complete this pull request review by 5/10/2021 for 4.0.0 release.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [X] Complete the PR definition above.
- [X] Ensure the PR title matches the feature or bugfix branch name.
- [X] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**, **Project(s)**, and **Milestone**
- [ ] After submitting the PR, select **Linked Issues** with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
