### PR TITLE
feature 986 TCPairs support LOOP_BY = VALID when LOOP_ORDER = processes

### DIFF
--- a/metplus/wrappers/command_builder.py
+++ b/metplus/wrappers/command_builder.py
@@ -2283,3 +2283,23 @@ class CommandBuilder:
              @returns METConfigInfo object
         """
         return met_config(**kwargs)
+
+    def get_start_time_input_dict(self):
+        """! Get the first run time specified in config. Used if only running
+        the wrapper once (LOOP_ORDER = processes).
+
+        @returns dictionary containing time information for first run time
+        """
+        use_init = util.is_loop_by_init(self.config)
+        if use_init is None:
+            self.log_error('Could not read time info')
+            return None
+
+
+        start_time, _, _ = util.get_start_end_interval_times(self.config)
+        if start_time is None:
+            self.log_error("Could not get start time")
+            return None
+
+        input_dict = util.set_input_dict(start_time, self.config, use_init)
+        return input_dict

--- a/metplus/wrappers/tc_pairs_wrapper.py
+++ b/metplus/wrappers/tc_pairs_wrapper.py
@@ -150,19 +150,8 @@ class TCPairsWrapper(CommandBuilder):
 
         self.handle_consensus()
 
-        init_time_fmt = self.config.getstr('config', 'INIT_TIME_FMT')
-        clock_time = datetime.datetime.strptime(
-            self.config.getstr('config',
-                               'CLOCK_TIME'),
-            '%Y%m%d%H%M%S'
-        )
-
-        init_beg = self.config.getraw('config', 'INIT_BEG')
-        init_beg_dt = util.get_time_obj(init_beg,
-                                        init_time_fmt,
-                                        clock_time,
-                                        logger=self.logger)
-        c_dict['INIT_BEG'] = init_beg_dt.strftime('%Y%m%d_%H%M%S')
+        # if looping by processes, get the init or valid beg time and run once
+        c_dict['INPUT_DICT'] = self.get_start_time_input_dict()
 
         c_dict['INIT_INCLUDE'] = util.getlist(
             self.get_wrapper_or_generic_config('INIT_INCLUDE')
@@ -360,11 +349,8 @@ class TCPairsWrapper(CommandBuilder):
     def run_all_times(self):
         """! Build up the command to invoke the MET tool tc_pairs.
         """
-        # use init begin as run time (start of the storm)
-        input_dict = {'init':
-                      datetime.datetime.strptime(self.c_dict['INIT_BEG'],
-                                                 '%Y%m%d_%H%M%S')
-                      }
+        # use first run time
+        input_dict = self.c_dict.get('INPUT_DICT')
 
         # if running in READ_ALL_FILES mode, call tc_pairs once and exit
         if self.c_dict['READ_ALL_FILES']:
@@ -536,10 +522,7 @@ class TCPairsWrapper(CommandBuilder):
             # add storm month to each cyclone item if reformatting SBU
             if self.c_dict['REFORMAT_DECK'] and \
                self.c_dict['REFORMAT_DECK_TYPE'] == 'SBU':
-                if time_info is None:
-                    storm_month = self.c_dict['INIT_BEG'][4:6]
-                else:
-                    storm_month = time_info['init'].strftime('%m')
+                storm_month = time_info['init'].strftime('%m')
                 cyclone = [storm_month + c for c in cyclone]
 
             cyclone = str(cyclone).replace("'", '"')
@@ -634,7 +617,7 @@ class TCPairsWrapper(CommandBuilder):
                 return []
 
             # Set up the environment variable to be used in the TCPairs Config
-            self.set_environment_variables(time_info)
+            self.set_environment_variables(time_storm_info)
 
             self.build()
 
@@ -911,7 +894,7 @@ class TCPairsWrapper(CommandBuilder):
         directories to search for files to let the application determine
         which data to process
 
-        @param input_dict dictionary containing init time set from INIT_BEG
+        @param input_dict dictionary containing some time information
         @returns list of tuples containing commands that are run and which env
          vars were set for the command
         """
@@ -939,7 +922,7 @@ class TCPairsWrapper(CommandBuilder):
                                                check_extension='.tcst'):
             return []
 
-        self.set_environment_variables(input_dict)
+        self.set_environment_variables(time_storm_info)
 
         self.build()
         return self.all_commands

--- a/metplus/wrappers/tc_pairs_wrapper.py
+++ b/metplus/wrappers/tc_pairs_wrapper.py
@@ -371,12 +371,16 @@ class TCPairsWrapper(CommandBuilder):
                 self.logger.info(f"Processing custom string: {custom_string}")
 
             input_dict['custom'] = custom_string
-            time_info = time_util.ti_calculate(input_dict)
-            if util.skip_time(time_info, self.c_dict.get('SKIP_TIMES', {})):
-                self.logger.debug('Skipping run time')
-                return
+            lead_seq = util.get_lead_sequence(self.config, input_dict)
+            for lead in lead_seq:
+                input_dict['lead'] = lead
+                time_info = time_util.ti_calculate(input_dict)
 
-            self.run_at_time_loop_string(time_info)
+                if util.skip_time(time_info, self.c_dict.get('SKIP_TIMES', {})):
+                    self.logger.debug('Skipping run time')
+                    return
+
+                self.run_at_time_loop_string(time_info)
 
     def run_at_time_loop_string(self, time_info):
         """! Create the arguments to run MET tc_pairs


### PR DESCRIPTION
Modified logic to allow loop by valid time for TCPairs when loop order = PROCESSES.

## Pull Request Testing ##

- [X] Describe testing already performed for these changes:</br>

Modified unit test logic to test when loop_order = PROCESSES and LOOP_BY = VALID

- [X] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

Review code changes and ensure no differences in automated tests.

- [X] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**

- [X] Do these changes include sufficient testing updates? **[Yes]**

- [X] Will this PR result in changes to the test suite? **[No]**</br>

- [X] Please complete this pull request review by **7/7/2021**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [X] Complete the PR definition above.
- [X] Ensure the PR title matches the feature or bugfix branch name.
- [X] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**
Select: **Organization** level software support **Project** or **Repository** level development cycle **Project**
Select: **Milestone** as the version that will include these changes
- [x] After submitting the PR, select **Linked issues** with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
