### PR TITLE
feature 1252 allow dictionary value for time_summary.width

### DIFF
--- a/internal_tests/pytests/ascii2nc/test_ascii2nc_wrapper.py
+++ b/internal_tests/pytests/ascii2nc/test_ascii2nc_wrapper.py
@@ -88,6 +88,14 @@ def ascii2nc_wrapper(metplus_config, config_path=None, config_overrides=None):
            'grib_code = [11, 204, 211];obs_var = [];'
            'type = ["min", "max", "range", "mean", "stdev", "median", "p80"];'
            'vld_freq = 0;vld_thresh = 0.0;}')}),
+        # width as dictionary
+        ({'ASCII2NC_TIME_SUMMARY_WIDTH': '{ beg = -21600; end = 0; }'},
+         {'METPLUS_TIME_SUMMARY_DICT':
+          ('time_summary = {flag = FALSE;raw_data = FALSE;beg = "000000";'
+           'end = "235959";step = 300;width = { beg = -21600; end = 0; };'
+           'grib_code = [11, 204, 211];obs_var = [];'
+           'type = ["min", "max", "range", "mean", "stdev", "median", "p80"];'
+           'vld_freq = 0;vld_thresh = 0.0;}')}),
 
         ({'ASCII2NC_TIME_SUMMARY_GRIB_CODES': '12, 203, 212'},
          {'METPLUS_TIME_SUMMARY_DICT':

--- a/metplus/wrappers/command_builder.py
+++ b/metplus/wrappers/command_builder.py
@@ -2012,10 +2012,11 @@ class CommandBuilder:
                                 'step',
                                 'TIME_SUMMARY_STEP')
 
-        self.set_met_config_int(tmp_dict,
-                                f'{app}_TIME_SUMMARY_WIDTH',
-                                'width',
-                                'TIME_SUMMARY_WIDTH')
+        self.set_met_config_string(tmp_dict,
+                                   f'{app}_TIME_SUMMARY_WIDTH',
+                                   'width',
+                                   'TIME_SUMMARY_WIDTH',
+                                   remove_quotes=True)
 
         self.set_met_config_list(tmp_dict,
                                  [f'{app}_TIME_SUMMARY_GRIB_CODES',


### PR DESCRIPTION
## Pull Request Testing ##

- [X] Describe testing already performed for these changes:</br>

Added unit test for setting dictionary value for width. Ensured all other tests pass.

- [X] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

Review code changes, ensure no failures in automated tests

- [X] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**

- [X] Do these changes include sufficient testing updates? **[Yes]**

- [X] Will this PR result in changes to the test suite? **[No]**</br>

- [X] Please complete this pull request review by **11/12/2021**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [X] Complete the PR definition above.
- [X] Ensure the PR title matches the feature or bugfix branch name.
- [X] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**
Select: **Organization** level software support **Project** or **Repository** level development cycle **Project**
Select: **Milestone** as the version that will include these changes
- [x] After submitting the PR, select **Linked issues** with the original issue number.
- [x] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [x] Close the linked issue and delete your feature or bugfix branch from GitHub.
