### PR TITLE
feature 1320 OMP_NUM_THREADS

### DIFF
--- a/docs/Users_Guide/glossary.rst
+++ b/docs/Users_Guide/glossary.rst
@@ -8693,3 +8693,13 @@ METplus Configuration Glossary
      :term:`VALID_TIME_FMT` or they will be skipped.
 
      | *Used by:* All
+
+   OMP_NUM_THREADS
+     Sets environment variable of the same name that determines the number
+     of threads to use in the MET executables. Defaults to 1 thread.
+     If the environment variable of the same name is already set in the
+     user's environment, then that value will be used instead of the value
+     set in the METplus configuration. A warning will be output if this is the
+     case and the values differ between them.
+
+     | *Used by:* All

--- a/docs/Users_Guide/systemconfiguration.rst
+++ b/docs/Users_Guide/systemconfiguration.rst
@@ -205,6 +205,13 @@ By default this is a directory called **stage** inside the
 
 This value is rarely changed, but it can be if desired.
 
+OMP_NUM_THREADS
+^^^^^^^^^^^^^^^
+
+If the MET executables were installed with threading support, then the number
+of threads used by the tools can be configured with this variable. See
+the glossary entry for :term:`OMP_NUM_THREADS` for more information.
+
 CONVERT
 ^^^^^^^
 

--- a/metplus/wrappers/command_builder.py
+++ b/metplus/wrappers/command_builder.py
@@ -70,6 +70,7 @@ class CommandBuilder:
         # list of environment variables to set before running command
         self.env_var_keys = [
             'MET_TMP_DIR',
+            'OMP_NUM_THREADS',
         ]
         if hasattr(self, 'WRAPPER_ENV_VAR_KEYS'):
             self.env_var_keys.extend(self.WRAPPER_ENV_VAR_KEYS)
@@ -116,6 +117,11 @@ class CommandBuilder:
         # set MET_TMP_DIR environment variable that controls
         # where the MET tools write temporary files
         self.env_var_dict['MET_TMP_DIR'] = self.config.getdir('TMP_DIR')
+
+        # set OMP_NUM_THREADS environment variable
+        self.env_var_dict['OMP_NUM_THREADS'] = (
+            self.config.getstr('config', 'OMP_NUM_THREADS')
+        )
 
         self.check_for_externals()
 

--- a/parm/metplus_config/defaults.conf
+++ b/parm/metplus_config/defaults.conf
@@ -57,6 +57,10 @@ GFDL_TRACKER_EXEC = /path/to/standalone_gfdl-vortextracker_v3.9a/trk_exec
 
 ###############################################################################
 # Runtime Configuration                                                       #
+#   * OMP_NUM_THREADS sets an environment variable of the same name that      #
+#     determines the number of threads to use in the MET executables. If the  #
+#     environment variable is already set in the user's environment, then     #
+#     that value will be used instead of the value set in this file.          #
 ###############################################################################
 
 
@@ -64,6 +68,7 @@ LOOP_ORDER = processes
 
 PROCESS_LIST = Usage
 
+OMP_NUM_THREADS = 1
 
 ###############################################################################
 # Log File Information (Where to write logs files)                            #


### PR DESCRIPTION
## Pull Request Testing ##

- [X] Describe testing already performed for these changes:</br>

Ran GridStat.conf use case to test that expected behavior occurs (see next section)

- [X] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

Obtain the code from branch **feature_1320_omp_num_threads** and run the GridStat.conf use case with 4 different criteria (outlined below) and confirm expected value is set for OMP_NUM_THREADS environment variable:

- [x] **1:** Confirm OMP_NUM_THREADS is unset and run use case. Run "unset OMP_NUM_THREADS" (bash) if it is set.

Example commands:
```
echo $OMP_NUM_THREADS
run_metplus.py ~/METplus/parm/use_cases/met_tool_wrapper/GridStat/GridStat.conf ~/user.conf
```
Example expected result: 1
> 01/05 17:31:56.162 metplus (command_builder.py:266) INFO: OMP_NUM_THREADS=1

- [x] **2:** Set OMP_NUM_THREADS METplus config variable and run use case.

Example commands:
```
run_metplus.py ~/METplus/parm/use_cases/met_tool_wrapper/GridStat/GridStat.conf ~/user.conf config.OMP_NUM_THREADS=2
```
Example expected result: 2
> 01/05 17:31:56.162 metplus (command_builder.py:266) INFO: OMP_NUM_THREADS=2

- [x] **3:** Set OMP_NUM_THREADS environment variable and run use case. Verify a warning message is output saying that the environment variable value is being used.

Example commands (bash):
```
export OMP_NUM_THREADS=3
run_metplus.py ~/METplus/parm/use_cases/met_tool_wrapper/GridStat/GridStat.conf ~/user.conf
```
Example expected result: 3
>01/05 17:31:48.773 metplus (met_util.py:267) WARNING: Config variable OMP_NUM_THREADS (1) will be overridden by the environment variable OMP_NUM_THREADS (3)
> ...
> 01/05 17:31:56.162 metplus (command_builder.py:266) INFO: OMP_NUM_THREADS=3

- [x] **4:** Set OMP_NUM_THREADS environment variable **and** OMP_NUM_THREADS METplus config variable and run use case. Verify a warning message is output saying that the environment variable value is being used.

Example commands (bash):
```
export OMP_NUM_THREADS=3
run_metplus.py ~/METplus/parm/use_cases/met_tool_wrapper/GridStat/GridStat.conf ~/user.conf config.OMP_NUM_THREADS=2
```
Example expected result: 3
>01/05 17:31:48.773 metplus (met_util.py:267) WARNING: Config variable OMP_NUM_THREADS (2) will be overridden by the environment variable OMP_NUM_THREADS (3)
> ...
> 01/05 17:31:56.162 metplus (command_builder.py:266) INFO: OMP_NUM_THREADS=3

- [X] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes or No]**

- [X] Do these changes include sufficient testing updates? **[Yes or No]**

- [X] Will this PR result in changes to the test suite? **[No]**</br>

- [X] Please complete this pull request review by **1/11/2022**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [X] Complete the PR definition above.
- [X] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**
Select: **Organization** level software support **Project** or **Repository** level development cycle **Project**
Select: **Milestone** as the version that will include these changes
- [x] After submitting the PR, select **Linked issues** with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
