### PR TITLE
bugfix 1486 pb2nc window variables

### DIFF
--- a/internal_tests/pytests/pb2nc/test_pb2nc_wrapper.py
+++ b/internal_tests/pytests/pb2nc/test_pb2nc_wrapper.py
@@ -189,6 +189,12 @@ def test_find_input_files(metplus_config, offsets, offset_to_find):
              'OBS_PB2NC_WINDOW_END': '1800',
          },
          {'METPLUS_OBS_WINDOW_DICT': 'obs_window = {beg = -1800;end = 1800;}'}),
+        # test legacy PB2NC_WINDOW_[BEGIN/END]
+        ({'PB2NC_WINDOW_BEGIN': '-1800', },
+         {'METPLUS_OBS_WINDOW_DICT': 'obs_window = {beg = -1800;}'}),
+
+        ({'PB2NC_WINDOW_END': '1800', },
+         {'METPLUS_OBS_WINDOW_DICT': 'obs_window = {end = 1800;}'}),
 
         ({'PB2NC_MASK_GRID': 'FULL', },
          {'METPLUS_MASK_DICT': 'mask = {grid = "FULL";}'}),

--- a/metplus/util/met_config.py
+++ b/metplus/util/met_config.py
@@ -165,6 +165,12 @@ def add_met_config_dict(config, app_name, output_dict, dict_name, items):
                 metplus_configs.append(
                     f"OBS_{app_name}_WINDOW_{suffix}".upper()
                 )
+
+                # also add support for legacy PB2NC_WINDOW_[BEGIN/END]
+                metplus_configs.append(
+                    f"{app_name}_WINDOW_{suffix}".upper()
+                )
+
                 # also add OBS_WINDOW_[BEGIN/END]
                 metplus_configs.append(f"OBS_WINDOW_{suffix}")
 

--- a/metplus/wrappers/command_builder.py
+++ b/metplus/wrappers/command_builder.py
@@ -328,9 +328,11 @@ class CommandBuilder:
                  ('END', 5400)]
         app = self.app_name.upper()
 
+        # check {app}_WINDOW_{edge} to support PB2NC_WINDOW_[BEGIN/END]
         for edge, default_val in edges:
             input_list = [f'OBS_{app}_WINDOW_{edge}',
                           f'{app}_OBS_WINDOW_{edge}',
+                          f'{app}_WINDOW_{edge}',
                           f'OBS_WINDOW_{edge}',
                          ]
             output_key = f'OBS_WINDOW_{edge}'


### PR DESCRIPTION
See #1486 for details. This PR fixes the read of PB2NC_WINDOW_BEGIN and PB2NC_WINDOW_END, which although named incorrectly used in METplus 3.1 to set obs_window begin and end for PB2NC.

## Pull Request Testing ##

- [X] Describe testing already performed for these changes:</br>

Added unit test to ensure variables are read properly.

- [X] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

Ensure all automated tests pass

- [X] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**
Just fixing broken behavior

- [X] Do these changes include sufficient testing updates? **[Yes]**

- [X] Will this PR result in changes to the test suite? **[No]**</br>

- [X] Please complete this pull request review by **3/14/2022`*.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [X] Review the source issue metadata (required labels, projects, and milestone).
- [X] Complete the PR definition above.
- [X] Ensure the PR title matches the feature or bugfix branch name.
- [ ] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**
Select: **Organization** level software support **Project** or **Repository** level development cycle **Project**
Select: **Milestone** as the version that will include these changes
- [ ] After submitting the PR, select **Linked issues** with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
