### PR TITLE
feature 33 (internal) disable UserScript wrapper

### DIFF
--- a/docs/Users_Guide/installation.rst
+++ b/docs/Users_Guide/installation.rst
@@ -256,8 +256,8 @@ External Components
 
 .. _external-components-gfdl-tracker:
 
-GFDL Tracker
-------------
+GFDL Tracker (optional)
+-----------------------
 
 - The standalone Geophysical Fluid Dynamics Laboratory (GFDL) vortex tracker
   is a program that objectively analyzes forecast data to provide an
@@ -277,6 +277,23 @@ GFDL Tracker
 
     -  Instructions on how to configure and use the GFDL tracker are found here
        https://dtcenter.org/sites/default/files/community-code/gfdl/standalone_tracker_UG_v3.9a.pdf
+
+Disable UserScript wrapper (optional)
+=====================================
+
+The UserScript wrapper allows any shell command or script to be run as part
+of a METplus use case. It is used to preprocess/postprocess data or to run
+intermediate commands between other wrappers.
+
+**If desired, this wrapper can be disabled upon installation to prevent
+security risks.** To disable the UserScript wrapper,
+simply remove the following file from the installation location::
+
+    METplus/metplus/wrapper/user_script_wrapper.py
+
+Please note that use cases provided with the METplus repository that utilize
+the UserScript wrapper will fail if attempted to run after it has been
+disabled.
 
 Add ush directory to shell path (optional)
 ==========================================

--- a/docs/Users_Guide/wrappers.rst
+++ b/docs/Users_Guide/wrappers.rst
@@ -8894,6 +8894,8 @@ referenced inside the user-defined script to obtain a list of the files that
 should be processed.
 See :term:`USER_SCRIPT_INPUT_TEMPLATE` for more information.
 
+Note: This wrapper may be disabled upon installation to prevent security risks.
+
 METplus Configuration
 ---------------------
 

--- a/metplus/util/met_util.py
+++ b/metplus/util/met_util.py
@@ -119,8 +119,13 @@ def run_metplus(config, process_list):
                     command_builder.run_all_times()
                     return 0
             except AttributeError:
-                raise NameError("There was a problem loading "
-                                f"{process} wrapper.")
+                logger.error("There was a problem loading "
+                             f"{process} wrapper.")
+                return 1
+            except ModuleNotFoundError:
+                logger.error(f"Could not load {process} wrapper. "
+                             "Wrapper may have been disabled.")
+                return 1
 
             processes.append(command_builder)
 


### PR DESCRIPTION
## Changes
* Updated documentation to include instructions on how to disable UserScript wrapper
* Catch exception thrown when a use case is run that calls a wrapper that is disabled to report error with suggestion that wrapper may be disabled before exiting gracefully


## Pull Request Testing ##

- [X] Describe testing already performed for these changes:</br>

To test this approach to disabling UserScript wrapper, I created branch feature_33i_remove_user_script where I removed the script per the instructions, removed the pytests for UserScript wrapper, commented out all use cases that runs UserScript wrapper from the internal_tests/use_cases/all_use_cases.txt file, and ran the full suite of tests. All of the use cases passed except for the ones that were disabled because they call UserScript wrapper, which failed as expected because the output from those use cases were not found.

The s2s:4 use case runs UserScript wrapper but was missed from the initial test, so it ran and crashed trying to import the wrapper. This prompted the changes to catch and log an error with a useful message in this case.

The s2s:12 use case ran and succeeded the diff test, presumably because there were no output files generated by this use case (possible because data is uploading into a database instead of written to disk?). We should consider updating the diff logic to properly test this use case.

I also removed metplus/wrappers/user_script_wrapper.py locally and ran a use case that includes UserScript in the PROCESS_LIST to verify that the error is logged and execution does not crash.

- [X] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

* Review documentation additions
  *  https://metplus.readthedocs.io/en/feature_33i_doc_remove_user_script/Users_Guide/installation.html
  *  https://metplus.readthedocs.io/en/feature_33i_doc_remove_user_script/Users_Guide/wrappers.html
* (Optionally) obtain branch, temporarily remove metplus/wrappers/user_script_wrapper.py, run any use case under parm/use_cases/met_tool_wrapper/UserScript, and review log output

- [X] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**

- [X] Do these changes include sufficient testing updates? **[Yes]**

- [X] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [X] Please complete this pull request review by **5/12/2022**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [X] Add any new Python packages to the [METplus Components Python Requirements](https://metplus.readthedocs.io/en/develop/Users_Guide/overview.html#metplus-components-python-requirements) table.
- [X] Review the source issue metadata (required labels, projects, and milestone).
- [X] Complete the PR definition above.
- [X] Ensure the PR title matches the feature or bugfix branch name.
- [X] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**
Select: **Organization** level software support **Project** or **Repository** level development cycle **Project**
Select: **Milestone** as the version that will include these changes
- [x] After submitting the PR, select **Linked issues** with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
