### PR TITLE
free up disk space in GHA runner environment

### DIFF
--- a/.github/jobs/free_disk_space.sh
+++ b/.github/jobs/free_disk_space.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+echo Checking disk usage before cleanup
+df -h
+
+echo Removing files as suggested by https://github.com/actions/virtual-environments/issues/2840
+
+sudo rm -rf /usr/share/dotnet
+sudo rm -rf /opt/ghc
+sudo rm -rf "/usr/local/share/boost"
+sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
+echo Checking disk usage after cleanup
+df -h

--- a/.github/jobs/free_disk_space.sh
+++ b/.github/jobs/free_disk_space.sh
@@ -3,12 +3,12 @@
 echo Checking disk usage before cleanup
 df -h
 
-echo Removing files as suggested by https://github.com/actions/virtual-environments/issues/2840
+printf "\nRemoving files as suggested by https://github.com/actions/virtual-environments/issues/2840"
 
 sudo rm -rf /usr/share/dotnet
 sudo rm -rf /opt/ghc
 sudo rm -rf "/usr/local/share/boost"
 sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
-echo Checking disk usage after cleanup
+printf "\nChecking disk usage after cleanup"
 df -h

--- a/.github/jobs/get_metviewer.sh
+++ b/.github/jobs/get_metviewer.sh
@@ -24,7 +24,7 @@ docker ps -a
 
 # commands to run inside METviewer container
 cmd="mysql -hmysql_mv -uroot -pmvuser -e\"create database mv_metplus_test;\";"
-cmd+="mysql -hmysql_mv -uroot -pmvuser mv_metplus_test < /METviewer/sql/mv_mysql.sql"
+cmd+="mysql -hmysql_mv -uroot -pmvuser mv_metplus_test < /METviewer-python/METdataio/METdbLoad/sql/mv_mysql.sql"
 cmd+=";mysql -hmysql_mv -uroot -pmvuser -e\"show databases;\""
 
 # execute commands inside metviewer container to create database

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -117,6 +117,9 @@ jobs:
 
       - uses: actions/checkout@v2
 
+      - name: Free disk space
+        run: .github/jobs/free_disk_space.sh
+
       - name: Create directories for database
         run: .github/jobs/create_dirs_for_database.sh
 


### PR DESCRIPTION
This is a quick fix that contains changes that were tested for PR #1697. I'd like to get these fixes into develop so that current development can continue to use the automated testing suite. The changes include:
* Updating the path to the sql file used to create the METviewer database for use cases that use METdbLoad -- the file was moved from the METviewer to a more appropriate location in the METdataio (formerly METdatadb) repository
* Remove files that are not needed for our testing environment (i.e. android dev tools) as recommended by GitHub developers

I am merging this without review since it has been tested and will allow the team to keep moving forward while the rest of the changes in PR #1697 are being evaluated.