### PR TITLE
update instructions to find issues for a bugfix release

### DIFF
--- a/docs/Release_Guide/release_steps/common/update_dtc_website.rst
+++ b/docs/Release_Guide/release_steps/common/update_dtc_website.rst
@@ -1,10 +1,12 @@
 Update DTC Website
 ------------------
 
+* Navigate to https://dtcenter.org and sign in to the Drupal interface.
+
 * Navigate to the downloads page for the |projectRepo| repository at
   https://dtcenter.org/community-code/metplus/download
 
-* Sign in to the Drupal interface and edit the Downloads page.
+* Click on the Edit button to edit the Downloads page.
 
 * Create a new *Software Release* for the newly released version by clicking
   on *Add New Release*.

--- a/docs/Release_Guide/release_steps/update_release_notes_bugfix.rst
+++ b/docs/Release_Guide/release_steps/update_release_notes_bugfix.rst
@@ -9,7 +9,7 @@ release. Open the following URL in a browser:
     https://github.com/orgs/dtcenter/projects?type=beta
 
 * Click on the project that corresponds to support for the release, i.e.
-  |projectRepo| Version X.Y Support
+  METplus Version X.Y Support
 
 * Navigate to the "Closed Issues" tab.
   **If this tab does not exist**, follow these instructions to create it:
@@ -21,6 +21,18 @@ release. Open the following URL in a browser:
   * Click on "Search or filter this view"
   * Enter the following info into the filter bar: **is:closed is:issue**
   * Click on the down arrow next to the view and click "Save changes"
+
+* Find the closed issues with dtcenter/|projectRepo| in the Repository column
+  that have been added since the last bugfix release for |projectRepo|.
+
+* Open the following URL in a browser:
+
+.. parsed-literal::
+
+    https://github.com/dtcenter/|projectRepo|/issues
+
+* Navigate to the |projectRepo| X.Y.Z Milestone to check for any issues
+  that may not appear in the METplus Version X.Y Support project board.
 
 * Update the release-notes.rst file found in the User's Guide directory.
 


### PR DESCRIPTION
Internal documentation changes only, so simply review changes for consistency.