### PR TITLE
Feature #1687 RuntimeFreq read only files needed for given run

### DIFF
--- a/.github/parm/use_case_groups.json
+++ b/.github/parm/use_case_groups.json
@@ -7,7 +7,7 @@
   {
     "category": "met_tool_wrapper",
     "index_list": "30-58",
-    "run": true
+    "run": false
   },
   {
     "category": "air_quality_and_comp",
@@ -77,7 +77,7 @@
   {
     "category": "medium_range",
     "index_list": "1-2",
-    "run": true
+    "run": false
   },
   {
     "category": "medium_range",
@@ -92,12 +92,12 @@
   {
     "category": "medium_range",
     "index_list": "7",
-    "run": true
+    "run": false
   },
   {
     "category": "medium_range",
     "index_list": "8",
-    "run": true
+    "run": false
   },
   {
     "category": "precipitation",
@@ -117,7 +117,7 @@
   {
     "category": "precipitation",
     "index_list": "3-7",
-    "run": true
+    "run": false
   },
   {
     "category": "precipitation",
@@ -127,7 +127,7 @@
   {
     "category": "s2s",
     "index_list": "0",
-    "run": true
+    "run": false
   },
   {
     "category": "s2s",
@@ -152,7 +152,7 @@
   {
     "category": "s2s",
     "index_list": "5",
-    "run": true
+    "run": false
   },
   {
     "category": "s2s",

--- a/.github/parm/use_case_groups.json
+++ b/.github/parm/use_case_groups.json
@@ -7,7 +7,7 @@
   {
     "category": "met_tool_wrapper",
     "index_list": "30-58",
-    "run": false
+    "run": true
   },
   {
     "category": "air_quality_and_comp",
@@ -77,7 +77,7 @@
   {
     "category": "medium_range",
     "index_list": "1-2",
-    "run": false
+    "run": true
   },
   {
     "category": "medium_range",
@@ -92,12 +92,12 @@
   {
     "category": "medium_range",
     "index_list": "7",
-    "run": false
+    "run": true
   },
   {
     "category": "medium_range",
     "index_list": "8",
-    "run": false
+    "run": true
   },
   {
     "category": "precipitation",
@@ -127,7 +127,7 @@
   {
     "category": "s2s",
     "index_list": "0",
-    "run": false
+    "run": true
   },
   {
     "category": "s2s",
@@ -152,7 +152,7 @@
   {
     "category": "s2s",
     "index_list": "5",
-    "run": false
+    "run": true
   },
   {
     "category": "s2s",

--- a/.github/parm/use_case_groups.json
+++ b/.github/parm/use_case_groups.json
@@ -2,12 +2,12 @@
   {
     "category": "met_tool_wrapper",
     "index_list": "0-29,59-61",
-    "run": true
+    "run": false
   },
   {
     "category": "met_tool_wrapper",
     "index_list": "30-58",
-    "run": true
+    "run": false
   },
   {
     "category": "air_quality_and_comp",
@@ -82,7 +82,7 @@
   {
     "category": "medium_range",
     "index_list": "3-5",
-    "run": true
+    "run": false
   },
   {
     "category": "medium_range",
@@ -132,22 +132,22 @@
   {
     "category": "s2s",
     "index_list": "1",
-    "run": true
+    "run": false
   },
   {
     "category": "s2s",
     "index_list": "2",
-    "run": true
+    "run": false
   },
   {
     "category": "s2s",
     "index_list": "3",
-    "run": true
+    "run": false
   },
   {
     "category": "s2s",
     "index_list": "4",
-    "run": true
+    "run": false
   },
   {
     "category": "s2s",
@@ -162,27 +162,27 @@
   {
     "category": "s2s_mid_lat",
     "index_list": "0-2",
-    "run": true
+    "run": false
   },
   {
     "category": "s2s_mid_lat",
     "index_list": "3",
-    "run": true
+    "run": false
   },
   {
     "category": "s2s_mjo",
     "index_list": "0-2",
-    "run": true
+    "run": false
   },
   {
     "category": "s2s_mjo",
     "index_list": "3",
-    "run": true
+    "run": false
   },
   {
     "category": "s2s_mjo",
     "index_list": "4",
-    "run": true
+    "run": false
   },
   {
     "category": "space_weather",
@@ -192,11 +192,11 @@
   {
     "category": "tc_and_extra_tc",
     "index_list": "0-2",
-    "run": true
+    "run": false
   },
   {
     "category": "tc_and_extra_tc",
     "index_list": "3-5",
-    "run": true
+    "run": false
   }
 ]

--- a/.github/parm/use_case_groups.json
+++ b/.github/parm/use_case_groups.json
@@ -2,12 +2,12 @@
   {
     "category": "met_tool_wrapper",
     "index_list": "0-29,59-61",
-    "run": false
+    "run": true
   },
   {
     "category": "met_tool_wrapper",
     "index_list": "30-58",
-    "run": false
+    "run": true
   },
   {
     "category": "air_quality_and_comp",
@@ -82,7 +82,7 @@
   {
     "category": "medium_range",
     "index_list": "3-5",
-    "run": false
+    "run": true
   },
   {
     "category": "medium_range",
@@ -132,22 +132,22 @@
   {
     "category": "s2s",
     "index_list": "1",
-    "run": false
+    "run": true
   },
   {
     "category": "s2s",
     "index_list": "2",
-    "run": false
+    "run": true
   },
   {
     "category": "s2s",
     "index_list": "3",
-    "run": false
+    "run": true
   },
   {
     "category": "s2s",
     "index_list": "4",
-    "run": false
+    "run": true
   },
   {
     "category": "s2s",
@@ -162,27 +162,27 @@
   {
     "category": "s2s_mid_lat",
     "index_list": "0-2",
-    "run": false
+    "run": true
   },
   {
     "category": "s2s_mid_lat",
     "index_list": "3",
-    "run": false
+    "run": true
   },
   {
     "category": "s2s_mjo",
     "index_list": "0-2",
-    "run": false
+    "run": true
   },
   {
     "category": "s2s_mjo",
     "index_list": "3",
-    "run": false
+    "run": true
   },
   {
     "category": "s2s_mjo",
     "index_list": "4",
-    "run": false
+    "run": true
   },
   {
     "category": "space_weather",
@@ -192,11 +192,11 @@
   {
     "category": "tc_and_extra_tc",
     "index_list": "0-2",
-    "run": false
+    "run": true
   },
   {
     "category": "tc_and_extra_tc",
     "index_list": "3-5",
-    "run": false
+    "run": true
   }
 ]

--- a/docs/Contributors_Guide/create_wrapper.rst
+++ b/docs/Contributors_Guide/create_wrapper.rst
@@ -22,7 +22,7 @@ For example, the new_tool wrapper would be named **NewToolWrapper**.
 Add Entry to LOWER_TO_WRAPPER_NAME Dictionary
 ---------------------------------------------
 
-In *metplus/util/doc_util.py*, add entries to the LOWER_TO_WRAPPER_NAME
+In *metplus/util/constants.py*, add entries to the LOWER_TO_WRAPPER_NAME
 dictionary so that the wrapper can be found in the PROCESS_LIST even if
 it is formatted differently. The key should be the wrapper name in all
 lower-case letters without any underscores. The value should be the class name

--- a/docs/Users_Guide/glossary.rst
+++ b/docs/Users_Guide/glossary.rst
@@ -1620,12 +1620,12 @@ METplus Configuration Glossary
      .. warning:: **DEPRECATED:** Please use :term:`FCST_THRESH_LIST` instead.
 
    FCST_THRESH_LIST
-     Specify the values of the FCST_THRESH column in the MET .stat file to use. This is optional in the METplus configuration file for running with :term:`LOOP_ORDER` = times.
+     Specify the values of the FCST_THRESH column in the MET .stat file to use.
 
      | *Used by:*  StatAnalysis
 
    OBS_THRESH_LIST
-     Specify the values of the OBS_THRESH column in the MET .stat file to use. This is optional in the METplus configuration file for running with :term:`LOOP_ORDER` = times.
+     Specify the values of the OBS_THRESH column in the MET .stat file to use.
 
      | *Used by:*  StatAnalysis
 
@@ -1647,7 +1647,7 @@ METplus Configuration Glossary
      .. warning:: **DEPRECATED:** Please use :term:`FCST_LEVEL_LIST` instead.
 
    FCST_LEVEL_LIST
-     Specify the values of the FCST_LEV column in the MET .stat file to use. This is optional in the METplus configuration file for running with :term:`LOOP_ORDER` = times.
+     Specify the values of the FCST_LEV column in the MET .stat file to use.
 
      | *Used by:*  StatAnalysis
 
@@ -1655,12 +1655,12 @@ METplus Configuration Glossary
      .. warning:: **DEPRECATED:** Please use :term:`FCST_VAR_LIST` instead.
 
    FCST_VAR_LIST
-     Specify the values of the FCST_VAR column in the MET .stat file to use. This is optional in the METplus configuration file for running with :term:`LOOP_ORDER` = times.
+     Specify the values of the FCST_VAR column in the MET .stat file to use.
 
      | *Used by:*  StatAnalysis
 
    FCST_UNITS_LIST
-     Specify the values of the FCST_UNITS column in the MET .stat file to use. This is optional in the METplus configuration file for running with :term:`LOOP_ORDER` = times.
+     Specify the values of the FCST_UNITS column in the MET .stat file to use.
 
      | *Used by:*  StatAnalysis
 
@@ -2319,7 +2319,7 @@ METplus Configuration Glossary
 
 
    LINE_TYPE_LIST
-     Specify the MET STAT line types to be considered. For TCMPRPlotter, this is optional in the METplus configuration file for running with :term:`LOOP_ORDER` = times.
+     Specify the MET STAT line types to be considered.
 
      | *Used by:*  MakePlots, StatAnalysis, TCMPRPlotter
 
@@ -2395,7 +2395,7 @@ METplus Configuration Glossary
      .. warning:: **DEPRECATED:** Please use :term:`LOOP_BY` instead.
 
    LOOP_ORDER
-     Control the looping order for METplus. Valid options are "times" or "processes". "times" runs all items in the :term:`PROCESS_LIST` for a single run time, then repeat until all times have been evaluated. "processes" runs each item in the :term:`PROCESS_LIST` for all times specified, then repeat for the next item in the :term:`PROCESS_LIST`.
+     .. warning:: **DEPRECATED:** This previously controlled the looping order for METplus. This was removed in v5.0.0. The wrappers will always execute the logic that was previously run when LOOP_ORDER = processes, which runs each item in the :term:`PROCESS_LIST` for all times specified, then repeat for the next item in the :term:`PROCESS_LIST`.
 
      | *Used by:*  All
 
@@ -3207,7 +3207,7 @@ METplus Configuration Glossary
      .. warning:: **DEPRECATED:** Please use :term:`OBS_LEVEL_LIST` instead.
 
    OBS_LEVEL_LIST
-     Specify the values of the OBS_LEV column in the MET .stat file to use. This is optional in the METplus configuration file for running with :term:`LOOP_ORDER` = times.
+     Specify the values of the OBS_LEV column in the MET .stat file to use.
 
      | *Used by:*  StatAnalysis
 
@@ -3215,12 +3215,12 @@ METplus Configuration Glossary
      .. warning:: **DEPRECATED:** Please use :term:`OBS_VAR_LIST` instead.
 
    OBS_VAR_LIST
-     Specify the values of the OBS_VAR column in the MET .stat file to use. This is optional in the METplus configuration file for running with :term:`LOOP_ORDER` = times.
+     Specify the values of the OBS_VAR column in the MET .stat file to use.
 
      | *Used by:*  StatAnalysis
 
    OBS_UNITS_LIST
-     Specify the values of the OBS_UNITS column in the MET .stat file to use. This is optional in the METplus configuration file for running with :term:`LOOP_ORDER` = times.
+     Specify the values of the OBS_UNITS column in the MET .stat file to use.
 
      | *Used by:*  StatAnalysis
 
@@ -3837,7 +3837,7 @@ METplus Configuration Glossary
      .. warning:: **DEPRECATED:** Please use :term:`MODEL<n>_STAT_ANALYSIS_DUMP_ROW_TEMPLATE` instead.
 
    MODEL<n>_STAT_ANALYSIS_DUMP_ROW_TEMPLATE
-     Specify the template to use for the stat_analysis dump_row file. A user customized template to use for the dump_row file. If left blank and a dump_row file is requested, a default version will be used. This is optional in the METplus configuration file for running with :term:`LOOP_ORDER` = times.
+     Specify the template to use for the stat_analysis dump_row file. A user customized template to use for the dump_row file. If left blank and a dump_row file is requested, a default version will be used.
 
      | *Used by:*  StatAnalysis
 
@@ -3853,7 +3853,7 @@ METplus Configuration Glossary
      .. warning:: **DEPRECATED:** Please use :term:`MODEL<n>_STAT_ANALYSIS_OUT_STAT_TEMPLATE` instead.
 
    MODEL<n>_STAT_ANALYSIS_OUT_STAT_TEMPLATE
-     Specify the template to use for the stat_analysis out_stat file. A user customized template to use for the out_stat file. If left blank and a out_stat file is requested, a default version will be used. This is optional in the METplus configuration file for running with :term:`LOOP_ORDER` = times.
+     Specify the template to use for the stat_analysis out_stat file. A user customized template to use for the out_stat file. If left blank and a out_stat file is requested, a default version will be used.
 
      | *Used by:*  StatAnalysis
 
@@ -7636,12 +7636,11 @@ METplus Configuration Glossary
      | *Used by:*  UserScript
 
    TC_PAIRS_RUN_ONCE
-     If True and LOOP_ORDER = processes, TCPairs will be run once using the
+     If True, TCPairs will be run once using the
      INIT_BEG or VALID_BEG value (depending on the value of LOOP_BY).
      This is the default setting and preserves the original logic of the
      wrapper. If this variable is set to False, then TCPairs will run once
-     for each run time iteration. If LOOP_ORDER = times, then TCPairs will
-     still run for each run time. The preferred configuration settings to
+     for each run time iteration. The preferred configuration settings to
      run TCPairs once for a range of init or valid times is to set INIT_BEG
      to INIT_END (if LOOP_BY = INIT) and define the range of init times to
      filter the data inside TCPairs with TC_PAIRS_INIT_BEG and

--- a/docs/Users_Guide/systemconfiguration.rst
+++ b/docs/Users_Guide/systemconfiguration.rst
@@ -1079,7 +1079,7 @@ Loop Order
 ----------
 
 The METplus wrappers will run all times for the first process defined in the
-:term:`PROCESS_LIST, then run all times for the second process, and so on.
+:term:`PROCESS_LIST`, then run all times for the second process, and so on.
 The :term:`LOOP_ORDER` variable has been deprecated in v5.0.0.
 This is the behavior that was previously executed when LOOP_ORDER = processes.
 

--- a/docs/Users_Guide/systemconfiguration.rst
+++ b/docs/Users_Guide/systemconfiguration.rst
@@ -1078,38 +1078,14 @@ the output directory.
 Loop Order
 ----------
 
-The METplus wrappers can be configured to loop first by times then
-processes or vice-versa. Looping by times first will run each process in
-the process list for a given run time, increment to the next run time, run
-each process in the process list, and so on. Looping by processes first
-will run all times for the first process, then run all times for the
-second process, and so on.
+The METplus wrappers will run all times for the first process defined in the
+:term:`PROCESS_LIST, then run all times for the second process, and so on.
+The :term:`LOOP_ORDER` variable has been deprecated in v5.0.0.
+This is the behavior that was previously executed when LOOP_ORDER = processes.
 
-**Example 1 Configuration**::
+**Example Configuration**::
 
   [config]
-  LOOP_ORDER = times
-
-  PROCESS_LIST = PCPCombine, GridStat
-
-  VALID_BEG = 20190201
-  VALID_END = 20190203
-  VALID_INCREMENT = 1d
-
-will run in the following order::
-
-  * PCPCombine at 2019-02-01
-  * GridStat   at 2019-02-01
-  * PCPCombine at 2019-02-02
-  * GridStat   at 2019-02-02
-  * PCPCombine at 2019-02-03
-  * GridStat   at 2019-02-03
-
-
-**Example 2 Configuration**::
-
-  [config]
-  LOOP_ORDER = processes
 
   PROCESS_LIST = PCPCombine, GridStat
 
@@ -1126,12 +1102,7 @@ will run in the following order::
   * GridStat   at 2019-02-02
   * GridStat   at 2019-02-03
 
-.. note::
-    If running a MET tool that processes data over a time range, such as
-    SeriesAnalysis or StatAnalysis, the tool must be run with
-    LOOP_ORDER = processes.
 
-    
 .. _Custom_Looping:
 
 Custom Looping
@@ -1782,15 +1753,13 @@ The possible values for the \*_RUNTIME_FREQ variables are:
   (init or valid and forecast lead combination).
   All filename templates are substituted with values.
 
-Note that :term:`LOOP_ORDER` must be set to processes to run these wrappers.
-Also note that the following example may not contain all of the configuration
+Note that the following example may not contain all of the configuration
 variables that are required for a successful run. The are intended to show
 how these variables affect how the data is processed.
 
 **SeriesAnalysis Examples**::
 
     [config]
-    LOOP_ORDER = processes
 
     LOOP_BY = INIT
     INIT_TIME_FMT = %Y%m%d%H

--- a/docs/Users_Guide/wrappers.rst
+++ b/docs/Users_Guide/wrappers.rst
@@ -3693,9 +3693,9 @@ Description
 -----------
 
 The MakePlots wrapper creates various statistical plots using python
-scripts for the various METplus Wrappers use cases. This can only be run
-following StatAnalysis wrapper when LOOP_ORDER = processes. To run
-MakePlots wrapper, include MakePlots in PROCESS_LIST.
+scripts for the various METplus Wrappers use cases.
+This can only be run following StatAnalysis wrapper.
+To run MakePlots wrapper, include MakePlots in PROCESS_LIST.
 
 METplus Configuration
 ---------------------
@@ -6829,71 +6829,15 @@ Description
 
 The StatAnalysis wrapper encapsulates the behavior of the MET
 stat_analysis tool. It provides the infrastructure to summarize and
-filter the MET .stat files. StatAnalysis wrapper can be run in two
-different methods. First is to look at the STAT lines for a single date,
-to use this method set LOOP_ORDER = times. Second is to look at the STAT
-lines over a span of dates, to use this method set LOOP_ORDER =
-processes. To run StatAnalysis wrapper, include StatAnalysis in
-PROCESS_LIST.
+filter the MET .stat files.
 
 METplus Configuration
 ---------------------
 
-The following values must be defined in the METplus Wrappers
-configuration file for running with LOOP_ORDER = times:
-
-| :term:`STAT_ANALYSIS_OUTPUT_DIR`
-| :term:`MODEL<n>_STAT_ANALYSIS_DUMP_ROW_TEMPLATE`
-| :term:`MODEL<n>_STAT_ANALYSIS_OUT_STAT_TEMPLATE`
-| :term:`LOG_STAT_ANALYSIS_VERBOSITY`
-| :term:`MODEL\<n\>`
-| :term:`MODEL<n>_OBTYPE`
-| :term:`MODEL<n>_STAT_ANALYSIS_LOOKIN_DIR`
-| :term:`MODEL_LIST`
-| :term:`GROUP_LIST_ITEMS`
-| :term:`LOOP_LIST_ITEMS`
-| :term:`STAT_ANALYSIS_CONFIG_FILE`
-| :term:`STAT_ANALYSIS_JOB_NAME`
-| :term:`STAT_ANALYSIS_JOB_ARGS`
-| :term:`STAT_ANALYSIS_MET_CONFIG_OVERRIDES`
-|
-
-The following values are **optional** in the METplus Wrappers
-configuration file for running with LOOP_ORDER = times:
-
-| :term:`DESC_LIST`
-| :term:`FCST_VALID_HOUR_LIST`
-| :term:`OBS_VALID_HOUR_LIST`
-| :term:`FCST_INIT_HOUR_LIST`
-| :term:`OBS_INIT_HOUR_LIST`
-| :term:`FCST_VAR_LIST`
-| :term:`OBS_VAR_LIST`
-| :term:`FCST_LEVEL_LIST`
-| :term:`OBS_LEVEL_LIST`
-| :term:`FCST_UNITS_LIST`
-| :term:`OBS_UNITS_LIST`
-| :term:`FCST_THRESH_LIST`
-| :term:`OBS_THRESH_LIST`
-| :term:`FCST_LEAD_LIST`
-| :term:`OBS_LEAD_LIST`
-| :term:`VX_MASK_LIST`
-| :term:`INTERP_MTHD_LIST`
-| :term:`INTERP_PNTS_LIST`
-| :term:`ALPHA_LIST`
-| :term:`COV_THRESH_LIST`
-| :term:`LINE_TYPE_LIST`
-| :term:`STAT_ANALYSIS_SKIP_IF_OUTPUT_EXISTS`
-| :term:`STAT_ANALYSIS_HSS_EC_VALUE`
-| :term:`STAT_ANALYSIS_OUTPUT_TEMPLATE`
-|
-
-The following values **must** be defined in the METplus Wrappers
-configuration file for running with LOOP_ORDER = processes:
+The following values **must** be defined in the METplus configuration file:
 
 | :term:`STAT_ANALYSIS_OUTPUT_DIR`
 | :term:`LOG_STAT_ANALYSIS_VERBOSITY`
-| :term:`DATE_TYPE`
-| :term:`STAT_ANALYSIS_CONFIG_FILE`
 | :term:`MODEL\<n\>`
 | :term:`MODEL<n>_OBTYPE`
 | :term:`MODEL<n>_STAT_ANALYSIS_LOOKIN_DIR`
@@ -6904,11 +6848,14 @@ configuration file for running with LOOP_ORDER = processes:
 | :term:`VX_MASK_LIST`
 | :term:`FCST_LEAD_LIST`
 | :term:`LINE_TYPE_LIST`
+| :term:`STAT_ANALYSIS_JOB_NAME`
+| :term:`STAT_ANALYSIS_JOB_ARGS`
+| :term:`STAT_ANALYSIS_MET_CONFIG_OVERRIDES`
 |
 
-The following values are optional in the METplus Wrappers configuration
-file for running with LOOP_ORDER = processes:
+The following values are optional in the METplus configuration file:
 
+| :term:`STAT_ANALYSIS_CONFIG_FILE`
 | :term:`VAR<n>_FOURIER_DECOMP`
 | :term:`VAR<n>_WAVE_NUM_LIST`
 | :term:`FCST_VALID_HOUR_LIST`
@@ -6923,6 +6870,8 @@ file for running with LOOP_ORDER = processes:
 | :term:`ALPHA_LIST`
 | :term:`STAT_ANALYSIS_HSS_EC_VALUE`
 | :term:`STAT_ANALYSIS_OUTPUT_TEMPLATE`
+| :term:`MODEL<n>_STAT_ANALYSIS_DUMP_ROW_TEMPLATE`
+| :term:`MODEL<n>_STAT_ANALYSIS_OUT_STAT_TEMPLATE`
 |
 
 .. warning:: **DEPRECATED:**

--- a/internal/tests/pytests/plotting/make_plots/test_make_plots_wrapper.py
+++ b/internal/tests/pytests/plotting/make_plots/test_make_plots_wrapper.py
@@ -47,7 +47,6 @@ def test_create_c_dict(metplus_config):
     mp = make_plots_wrapper(metplus_config)
     # Test 1
     c_dict = mp.create_c_dict()
-    assert(c_dict['LOOP_ORDER'] == 'processes')
     # NOTE: MakePlots relies on output from StatAnalysis
     #       so its input resides in the output of StatAnalysis
     assert(c_dict['INPUT_BASE_DIR'] == mp.config.getdir('OUTPUT_BASE')

--- a/internal/tests/pytests/wrappers/series_analysis/test_series_analysis.py
+++ b/internal/tests/pytests/wrappers/series_analysis/test_series_analysis.py
@@ -313,9 +313,13 @@ def test_series_analysis_single_field(metplus_config, config_overrides,
 
     config_file = wrapper.c_dict.get('CONFIG_FILE')
     out_dir = wrapper.c_dict.get('OUTPUT_DIR')
+    prefix = 'series_analysis_files_'
+    suffix = '_init_20050807000000_valid_ALL_lead_ALL.txt'
+    fcst_file = f'{prefix}fcst{suffix}'
+    obs_file = f'{prefix}obs{suffix}'
     expected_cmds = [(f"{app_path} "
-                      f"-fcst {out_dir}/FCST_FILES "
-                      f"-obs {out_dir}/OBS_FILES "
+                      f"-fcst {out_dir}/{fcst_file} "
+                      f"-obs {out_dir}/{obs_file} "
                       f"-out {out_dir}/2005080700 "
                       f"-config {config_file} {verbosity}"),
                      ]
@@ -355,8 +359,6 @@ def test_get_fcst_file_info(metplus_config):
     expected_num = str(9)
     expected_beg = '000'
     expected_end = '048'
-
-    time_info = {'storm_id': storm_id, 'lead': 0, 'valid': '', 'init': ''}
 
     wrapper = series_analysis_wrapper(metplus_config)
     wrapper.c_dict['FCST_INPUT_DIR'] = '/fake/path/of/file'
@@ -404,29 +406,6 @@ def test_get_storms_list(metplus_config):
     assert storm_list == expected_storm_list
 
 
-# added list of all files for reference for creating subsets
-all_fake_fcst = ['fcst/20141214_00/ML1201072014/FCST_TILE_F000_gfs_4_20141214_0000_000.nc',
-                 'fcst/20141214_00/ML1221072014/FCST_TILE_F000_gfs_4_20141214_0000_000.nc',
-                 'fcst/20141214_00/ML1201072014/FCST_TILE_F006_gfs_4_20141214_0000_006.nc',
-                 'fcst/20141214_00/ML1221072014/FCST_TILE_F006_gfs_4_20141214_0000_006.nc',
-                 'fcst/20141214_00/ML1201072014/FCST_TILE_F012_gfs_4_20141214_0000_012.nc',
-                 'fcst/20141214_00/ML1221072014/FCST_TILE_F012_gfs_4_20141214_0000_012.nc',
-                 'fcst/20141215_00/ML1291072014/FCST_TILE_F000_gfs_4_20141215_0000_000.nc',
-                 'fcst/20141215_00/ML1291072014/FCST_TILE_F006_gfs_4_20141215_0000_006.nc',
-                 'fcst/20141215_00/ML1291072014/FCST_TILE_F012_gfs_4_20141215_0000_012.nc',
-                  ]
-all_fake_obs = ['obs/20141214_00/ML1201072014/OBS_TILE_F000_gfs_4_20141214_0000_000.nc',
-                 'obs/20141214_00/ML1221072014/OBS_TILE_F000_gfs_4_20141214_0000_000.nc',
-                 'obs/20141214_00/ML1201072014/OBS_TILE_F006_gfs_4_20141214_0000_006.nc',
-                 'obs/20141214_00/ML1221072014/OBS_TILE_F006_gfs_4_20141214_0000_006.nc',
-                 'obs/20141214_00/ML1201072014/OBS_TILE_F012_gfs_4_20141214_0000_012.nc',
-                 'obs/20141214_00/ML1221072014/OBS_TILE_F012_gfs_4_20141214_0000_012.nc',
-                 'obs/20141215_00/ML1291072014/OBS_TILE_F000_gfs_4_20141215_0000_000.nc',
-                 'obs/20141215_00/ML1291072014/OBS_TILE_F006_gfs_4_20141215_0000_006.nc',
-                 'obs/20141215_00/ML1291072014/OBS_TILE_F012_gfs_4_20141215_0000_012.nc',
-                  ]
-
-
 @pytest.mark.parametrize(
         'time_info, expect_fcst_subset, expect_obs_subset', [
         # filter by init all storms
@@ -435,16 +414,16 @@ all_fake_obs = ['obs/20141214_00/ML1201072014/OBS_TILE_F000_gfs_4_20141214_0000_
           'lead': '*',
           'storm_id': '*'},
          ['fcst/20141214_00/ML1201072014/FCST_TILE_F000_gfs_4_20141214_0000_000.nc',
-          'fcst/20141214_00/ML1221072014/FCST_TILE_F000_gfs_4_20141214_0000_000.nc',
           'fcst/20141214_00/ML1201072014/FCST_TILE_F006_gfs_4_20141214_0000_006.nc',
-          'fcst/20141214_00/ML1221072014/FCST_TILE_F006_gfs_4_20141214_0000_006.nc',
           'fcst/20141214_00/ML1201072014/FCST_TILE_F012_gfs_4_20141214_0000_012.nc',
+          'fcst/20141214_00/ML1221072014/FCST_TILE_F000_gfs_4_20141214_0000_000.nc',
+          'fcst/20141214_00/ML1221072014/FCST_TILE_F006_gfs_4_20141214_0000_006.nc',
           'fcst/20141214_00/ML1221072014/FCST_TILE_F012_gfs_4_20141214_0000_012.nc',],
          ['obs/20141214_00/ML1201072014/OBS_TILE_F000_gfs_4_20141214_0000_000.nc',
-          'obs/20141214_00/ML1221072014/OBS_TILE_F000_gfs_4_20141214_0000_000.nc',
           'obs/20141214_00/ML1201072014/OBS_TILE_F006_gfs_4_20141214_0000_006.nc',
-          'obs/20141214_00/ML1221072014/OBS_TILE_F006_gfs_4_20141214_0000_006.nc',
           'obs/20141214_00/ML1201072014/OBS_TILE_F012_gfs_4_20141214_0000_012.nc',
+          'obs/20141214_00/ML1221072014/OBS_TILE_F000_gfs_4_20141214_0000_000.nc',
+          'obs/20141214_00/ML1221072014/OBS_TILE_F006_gfs_4_20141214_0000_006.nc',
           'obs/20141214_00/ML1221072014/OBS_TILE_F012_gfs_4_20141214_0000_012.nc',]),
         # filter by init single storm
         ({'init': datetime(2014, 12, 14, 0, 0),
@@ -526,10 +505,10 @@ def test_get_all_files_and_subset(metplus_config, time_info, expect_fcst_subset,
 
     expected_fcst = [
         'fcst/20141214_00/ML1201072014/FCST_TILE_F000_gfs_4_20141214_0000_000.nc',
-        'fcst/20141214_00/ML1221072014/FCST_TILE_F000_gfs_4_20141214_0000_000.nc',
         'fcst/20141214_00/ML1201072014/FCST_TILE_F006_gfs_4_20141214_0000_006.nc',
-        'fcst/20141214_00/ML1221072014/FCST_TILE_F006_gfs_4_20141214_0000_006.nc',
         'fcst/20141214_00/ML1201072014/FCST_TILE_F012_gfs_4_20141214_0000_012.nc',
+        'fcst/20141214_00/ML1221072014/FCST_TILE_F000_gfs_4_20141214_0000_000.nc',
+        'fcst/20141214_00/ML1221072014/FCST_TILE_F006_gfs_4_20141214_0000_006.nc',
         'fcst/20141214_00/ML1221072014/FCST_TILE_F012_gfs_4_20141214_0000_012.nc',
     ]
     expected_fcst_files = []
@@ -539,10 +518,10 @@ def test_get_all_files_and_subset(metplus_config, time_info, expect_fcst_subset,
 
     expected_obs = [
         'obs/20141214_00/ML1201072014/OBS_TILE_F000_gfs_4_20141214_0000_000.nc',
-        'obs/20141214_00/ML1221072014/OBS_TILE_F000_gfs_4_20141214_0000_000.nc',
         'obs/20141214_00/ML1201072014/OBS_TILE_F006_gfs_4_20141214_0000_006.nc',
-        'obs/20141214_00/ML1221072014/OBS_TILE_F006_gfs_4_20141214_0000_006.nc',
         'obs/20141214_00/ML1201072014/OBS_TILE_F012_gfs_4_20141214_0000_012.nc',
+        'obs/20141214_00/ML1221072014/OBS_TILE_F000_gfs_4_20141214_0000_000.nc',
+        'obs/20141214_00/ML1221072014/OBS_TILE_F006_gfs_4_20141214_0000_006.nc',
         'obs/20141214_00/ML1221072014/OBS_TILE_F012_gfs_4_20141214_0000_012.nc',
     ]
     expected_obs_files = []
@@ -550,15 +529,33 @@ def test_get_all_files_and_subset(metplus_config, time_info, expect_fcst_subset,
         expected_obs_files.append(os.path.join(tile_input_dir, expected))
 
     # convert list of lists into a single list to compare to expected results
-    fcst_files = [item['fcst'] for item in wrapper.c_dict['ALL_FILES']]
+    fcst_files = []
+    obs_files = []
+    for item in wrapper.c_dict['ALL_FILES']:
+        for key, value in item.items():
+            if key.startswith('fcst'):
+                fcst_files.append(value)
+            if key.startswith('obs'):
+                obs_files.append(value)
     fcst_files = [item for sub in fcst_files for item in sub]
-    obs_files = [item['obs'] for item in wrapper.c_dict['ALL_FILES']]
     obs_files = [item for sub in obs_files for item in sub]
-
+    fcst_files.sort()
+    obs_files.sort()
     assert fcst_files == expected_fcst_files
     assert obs_files == expected_obs_files
 
-    fcst_files_sub, obs_files_sub = wrapper.subset_input_files(time_info)
+    list_file_dict = wrapper.subset_input_files(time_info)
+    fcst_files_sub = []
+    obs_files_sub = []
+    for key, value in list_file_dict.items():
+        if key.startswith('fcst'):
+            with open(value, 'r') as file_handle:
+                fcst_files_sub.extend(file_handle.read().splitlines()[1:])
+        if key.startswith('obs'):
+            with open(value, 'r') as file_handle:
+                obs_files_sub.extend(file_handle.read().splitlines()[1:])
+    fcst_files_sub.sort()
+    obs_files_sub.sort()
     assert fcst_files_sub and obs_files_sub
     assert len(fcst_files_sub) == len(obs_files_sub)
 
@@ -571,7 +568,7 @@ def test_get_all_files_and_subset(metplus_config, time_info, expect_fcst_subset,
 
 @pytest.mark.parametrize(
         'config_overrides, time_info, storm_id, lead_group, expect_fcst_subset, expect_obs_subset', [
-        # filter by init all storms
+        # 0: filter by init all storms
         ({'LEAD_SEQ': '0H, 6H, 12H',
           'SERIES_ANALYSIS_OUTPUT_TEMPLATE': "{init?fmt=%Y%m%d_%H}/{storm_id}/series_{fcst_name}_{fcst_level}.nc",
           'TEST_OUTPUT_DIRNAME': 'byinitallstorms'},
@@ -593,7 +590,7 @@ def test_get_all_files_and_subset(metplus_config, time_info, expect_fcst_subset,
           'obs/20141214_00/ML1221072014/OBS_TILE_F006_gfs_4_20141214_0000_006.nc',
           'obs/20141214_00/ML1201072014/OBS_TILE_F012_gfs_4_20141214_0000_012.nc',
           'obs/20141214_00/ML1221072014/OBS_TILE_F012_gfs_4_20141214_0000_012.nc',]),
-        # filter by init single storm
+        # 1: filter by init single storm
         ({'LEAD_SEQ': '0H, 6H, 12H',
           'SERIES_ANALYSIS_OUTPUT_TEMPLATE': "{init?fmt=%Y%m%d_%H}/{storm_id}/series_{fcst_name}_{fcst_level}.nc",
           'TEST_OUTPUT_DIRNAME': 'byinitstormA'},
@@ -611,7 +608,7 @@ def test_get_all_files_and_subset(metplus_config, time_info, expect_fcst_subset,
           'obs/20141214_00/ML1201072014/OBS_TILE_F006_gfs_4_20141214_0000_006.nc',
           'obs/20141214_00/ML1201072014/OBS_TILE_F012_gfs_4_20141214_0000_012.nc',
          ]),
-        # filter by init another single storm
+        # 2: filter by init another single storm
         ({'LEAD_SEQ': '0H, 6H, 12H',
           'SERIES_ANALYSIS_OUTPUT_TEMPLATE': "{init?fmt=%Y%m%d_%H}/{storm_id}/series_{fcst_name}_{fcst_level}.nc",
           'TEST_OUTPUT_DIRNAME': 'byinitstormB'},
@@ -629,7 +626,7 @@ def test_get_all_files_and_subset(metplus_config, time_info, expect_fcst_subset,
           'obs/20141214_00/ML1221072014/OBS_TILE_F006_gfs_4_20141214_0000_006.nc',
           'obs/20141214_00/ML1221072014/OBS_TILE_F012_gfs_4_20141214_0000_012.nc',
          ]),
-        # filter by lead all storms
+        # 3: filter by lead all storms
         ({'LEAD_SEQ': '0H, 6H, 12H',
           'SERIES_ANALYSIS_OUTPUT_TEMPLATE': "series_{fcst_name}_{fcst_level}.nc",
           'TEST_OUTPUT_DIRNAME': 'byleadallstorms'},
@@ -645,7 +642,7 @@ def test_get_all_files_and_subset(metplus_config, time_info, expect_fcst_subset,
          ['obs/20141214_00/ML1201072014/OBS_TILE_F006_gfs_4_20141214_0000_006.nc',
           'obs/20141214_00/ML1221072014/OBS_TILE_F006_gfs_4_20141214_0000_006.nc',
          ]),
-        # filter by lead 1 storm
+        # 4: filter by lead 1 storm
         ({'LEAD_SEQ': '0H, 6H, 12H',
           'SERIES_ANALYSIS_OUTPUT_TEMPLATE': "series_{fcst_name}_{fcst_level}.nc",
           'TEST_OUTPUT_DIRNAME': 'byleadstormA'},
@@ -659,7 +656,7 @@ def test_get_all_files_and_subset(metplus_config, time_info, expect_fcst_subset,
          ],
          ['obs/20141214_00/ML1201072014/OBS_TILE_F006_gfs_4_20141214_0000_006.nc',
          ]),
-        # filter by lead another storm
+        # 5: filter by lead another storm
         ({'LEAD_SEQ': '0H, 6H, 12H',
           'SERIES_ANALYSIS_OUTPUT_TEMPLATE': "series_{fcst_name}_{fcst_level}.nc",
           'TEST_OUTPUT_DIRNAME': 'byleadstormB'},
@@ -673,7 +670,7 @@ def test_get_all_files_and_subset(metplus_config, time_info, expect_fcst_subset,
          ],
          ['obs/20141214_00/ML1221072014/OBS_TILE_F006_gfs_4_20141214_0000_006.nc',
          ]),
-        # filter by lead groups A all storms
+        # 6: filter by lead groups A all storms
         ({'LEAD_SEQ_1': '0H, 6H',
           'LEAD_SEQ_1_LABEL': 'Group1',
           'LEAD_SEQ_2': '12H',
@@ -695,7 +692,7 @@ def test_get_all_files_and_subset(metplus_config, time_info, expect_fcst_subset,
           'obs/20141214_00/ML1201072014/OBS_TILE_F006_gfs_4_20141214_0000_006.nc',
           'obs/20141214_00/ML1221072014/OBS_TILE_F006_gfs_4_20141214_0000_006.nc',
          ]),
-        # filter by lead groups B all storms
+        # 7: filter by lead groups B all storms
         ({'LEAD_SEQ_1': '0H, 6H',
           'LEAD_SEQ_1_LABEL': 'Group1',
           'LEAD_SEQ_2': '12H',
@@ -730,32 +727,34 @@ def test_get_fcst_and_obs_path(metplus_config, config_overrides,
     all_config_overrides.update(config_overrides)
     wrapper = series_analysis_wrapper(metplus_config, all_config_overrides)
     stat_input_dir, tile_input_dir = get_input_dirs(wrapper.config)
-    fcst_input_dir = os.path.join(tile_input_dir,
-                                  'fcst')
-    obs_input_dir = os.path.join(tile_input_dir,
-                                 'obs')
+    fcst_input_dir = os.path.join(tile_input_dir, 'fcst')
+    obs_input_dir = os.path.join(tile_input_dir, 'obs')
 
     stat_input_template = 'another_fake_filter_{init?fmt=%Y%m%d_%H}.tcst'
 
     wrapper.c_dict['TC_STAT_INPUT_DIR'] = stat_input_dir
     wrapper.c_dict['TC_STAT_INPUT_TEMPLATE'] = stat_input_template
-    wrapper.c_dict['RUN_ONCE_PER_STORM_ID'] = True
     wrapper.c_dict['FCST_INPUT_DIR'] = fcst_input_dir
     wrapper.c_dict['OBS_INPUT_DIR'] = obs_input_dir
     test_out_dirname = wrapper.config.getstr('config', 'TEST_OUTPUT_DIRNAME')
     output_dir = os.path.join(wrapper.config.getdir('OUTPUT_BASE'),
-                              'series_by',
-                              'output',
-                              test_out_dirname)
+                              'series_by', 'output', test_out_dirname)
     wrapper.c_dict['OUTPUT_DIR'] = output_dir
 
-    assert wrapper.get_all_files()
+    fcst_id = 'fcst'
+    obs_id = 'obs'
 
     # read output files and compare to expected list
     if storm_id == '*':
         storm_dir = 'all_storms'
+        wrapper.c_dict['RUN_ONCE_PER_STORM_ID'] = False
     else:
         storm_dir = storm_id
+        wrapper.c_dict['RUN_ONCE_PER_STORM_ID'] = True
+        fcst_id = f'{fcst_id}_{storm_id}'
+        obs_id = f'{obs_id}_{storm_id}'
+
+    assert wrapper.get_all_files()
 
     templates = config_overrides['SERIES_ANALYSIS_OUTPUT_TEMPLATE'].split('/')
     if len(templates) == 1:
@@ -763,21 +762,13 @@ def test_get_fcst_and_obs_path(metplus_config, config_overrides,
     else:
         output_prefix = os.path.join('20141214_00', storm_dir)
 
-    if lead_group:
-        leads = lead_group[1]
-    else:
-        leads = None
-    fcst_list_file = wrapper._get_ascii_filename('FCST', storm_id, leads)
-    fcst_file_path = os.path.join(output_dir,
-                                  output_prefix,
-                                  fcst_list_file)
+    fcst_list_file = wrapper.get_list_file_name(time_info, fcst_id)
+    fcst_file_path = os.path.join(output_dir, output_prefix, fcst_list_file)
     if os.path.exists(fcst_file_path):
         os.remove(fcst_file_path)
 
-    obs_list_file = wrapper._get_ascii_filename('OBS', storm_id, leads)
-    obs_file_path = os.path.join(output_dir,
-                                  output_prefix,
-                                  obs_list_file)
+    obs_list_file = wrapper.get_list_file_name(time_info, obs_id)
+    obs_file_path = os.path.join(output_dir, output_prefix, obs_list_file)
     if os.path.exists(obs_file_path):
         os.remove(obs_file_path)
 
@@ -790,6 +781,7 @@ def test_get_fcst_and_obs_path(metplus_config, config_overrides,
         actual_fcsts = file_handle.readlines()
     actual_fcsts = [item.strip() for item in actual_fcsts[1:]]
 
+    assert len(actual_fcsts) == len(expect_fcst_subset)
     for actual_file, expected_file in zip(actual_fcsts, expect_fcst_subset):
         actual_file = actual_file.replace(tile_input_dir, '').lstrip('/')
         assert actual_file == expected_file

--- a/internal/tests/pytests/wrappers/series_analysis/test_series_analysis.py
+++ b/internal/tests/pytests/wrappers/series_analysis/test_series_analysis.py
@@ -798,59 +798,10 @@ def test_get_fcst_and_obs_path(metplus_config, config_overrides,
         actual_obs_files = file_handle.readlines()
     actual_obs_files = [item.strip() for item in actual_obs_files[1:]]
 
+    assert len(actual_obs_files) == len(expect_obs_subset)
     for actual_file, expected_file in zip(actual_obs_files, expect_obs_subset):
         actual_file = actual_file.replace(tile_input_dir, '').lstrip('/')
         assert actual_file == expected_file
-
-
-@pytest.mark.parametrize(
-        'storm_id, leads, expected_result', [
-        # storm ID, no leads
-        ('ML1221072014', None, '_FILES_ML1221072014'),
-        # no storm ID no leads
-        ('*', None, '_FILES'),
-        # storm ID, 1 lead
-        ('ML1221072014', [relativedelta(hours=12)], '_FILES_ML1221072014_F012'),
-        # no storm ID, 1 lead
-        ('*', [relativedelta(hours=12)], '_FILES_F012'),
-        # storm ID, 2 leads
-        ('ML1221072014', [relativedelta(hours=18),
-                                  relativedelta(hours=12)],
-         '_FILES_ML1221072014_F012_to_F018'),
-        # no storm ID, 2 leads
-        ('*', [relativedelta(hours=18),
-                       relativedelta(hours=12)],
-         '_FILES_F012_to_F018'),
-        # storm ID, 3 leads
-        ('ML1221072014', [relativedelta(hours=15),
-                                  relativedelta(hours=18),
-                                  relativedelta(hours=12)],
-         '_FILES_ML1221072014_F012_to_F018'),
-        # no storm ID, 3 leads
-        ('*', [relativedelta(hours=15),
-                       relativedelta(hours=18),
-                       relativedelta(hours=12)],
-         '_FILES_F012_to_F018'),
-    ]
-)
-@pytest.mark.wrapper_a
-def test_get_ascii_filename(metplus_config, storm_id, leads,
-                            expected_result):
-    wrapper = series_analysis_wrapper(metplus_config)
-    for data_type in ['FCST', 'OBS']:
-        actual_result = wrapper._get_ascii_filename(data_type,
-                                                   storm_id,
-                                                   leads)
-        assert actual_result == f"{data_type}{expected_result}"
-
-        if leads is None:
-            return
-
-        lead_seconds = [ti_get_seconds_from_lead(item) for item in leads]
-        actual_result = wrapper._get_ascii_filename(data_type,
-                                                   storm_id,
-                                                   lead_seconds)
-        assert actual_result == f"{data_type}{expected_result}"
 
 
 @pytest.mark.parametrize(

--- a/internal/tests/pytests/wrappers/stat_analysis/test_stat_analysis.py
+++ b/internal/tests/pytests/wrappers/stat_analysis/test_stat_analysis.py
@@ -54,7 +54,6 @@ def test_create_c_dict(metplus_config):
     st = stat_analysis_wrapper(metplus_config)
     # Test 1
     c_dict = st.create_c_dict()
-    assert c_dict['LOOP_ORDER'] == 'times'
     assert(os.path.realpath(c_dict['CONFIG_FILE']) == (METPLUS_BASE+'/internal/tests/'
                                                        +'config/STATAnalysisConfig'))
     assert(c_dict['OUTPUT_DIR'] == (st.config.getdir('OUTPUT_BASE')

--- a/metplus/util/config_metplus.py
+++ b/metplus/util/config_metplus.py
@@ -1000,7 +1000,6 @@ def check_for_deprecated_config(config):
     #     modify the code to handle both variables accordingly
     deprecated_dict = {
         'LOOP_BY_INIT' : {'sec' : 'config', 'alt' : 'LOOP_BY', 'copy': False},
-        'LOOP_METHOD' : {'sec' : 'config', 'alt' : 'LOOP_ORDER'},
         'PREPBUFR_DIR_REGEX' : {'sec' : 'regex_pattern', 'alt' : None},
         'PREPBUFR_FILE_REGEX' : {'sec' : 'regex_pattern', 'alt' : None},
         'OBS_INPUT_DIR_REGEX' : {'sec' : 'regex_pattern', 'alt' : 'OBS_POINT_STAT_INPUT_DIR', 'copy': False},

--- a/metplus/util/constants.py
+++ b/metplus/util/constants.py
@@ -1,3 +1,43 @@
+# dictionary used by get_wrapper_name function to easily convert wrapper
+# name in many formats to the correct name of the wrapper class
+LOWER_TO_WRAPPER_NAME = {
+    'ascii2nc': 'ASCII2NC',
+    'cycloneplotter': 'CyclonePlotter',
+    'ensemblestat': 'EnsembleStat',
+    'example': 'Example',
+    'extracttiles': 'ExtractTiles',
+    'gempaktocf': 'GempakToCF',
+    'genvxmask': 'GenVxMask',
+    'genensprod': 'GenEnsProd',
+    'gfdltracker': 'GFDLTracker',
+    'griddiag': 'GridDiag',
+    'gridstat': 'GridStat',
+    'ioda2nc': 'IODA2NC',
+    'makeplots': 'MakePlots',
+    'metdbload': 'METDbLoad',
+    'mode': 'MODE',
+    'mtd': 'MTD',
+    'modetimedomain': 'MTD',
+    'pb2nc': 'PB2NC',
+    'pcpcombine': 'PCPCombine',
+    'plotdataplane': 'PlotDataPlane',
+    'plotpointobs': 'PlotPointObs',
+    'point2grid': 'Point2Grid',
+    'pointtogrid': 'Point2Grid',
+    'pointstat': 'PointStat',
+    'pyembedingest': 'PyEmbedIngest',
+    'regriddataplane': 'RegridDataPlane',
+    'seriesanalysis': 'SeriesAnalysis',
+    'statanalysis': 'StatAnalysis',
+    'tcgen': 'TCGen',
+    'tcpairs': 'TCPairs',
+    'tcrmw': 'TCRMW',
+    'tcstat': 'TCStat',
+    'tcmprplotter': 'TCMPRPlotter',
+    'usage': 'Usage',
+    'userscript': 'UserScript',
+}
+
 # supported file extensions that will automatically be uncompressed
 COMPRESSION_EXTENSIONS = [
     '.gz',

--- a/metplus/util/constants.py
+++ b/metplus/util/constants.py
@@ -1,3 +1,5 @@
+# Constant variables used throughout the METplus wrappers source code
+
 # dictionary used by get_wrapper_name function to easily convert wrapper
 # name in many formats to the correct name of the wrapper class
 LOWER_TO_WRAPPER_NAME = {

--- a/metplus/util/doc_util.py
+++ b/metplus/util/doc_util.py
@@ -3,45 +3,8 @@
 import sys
 import os
 
-# dictionary used by get_wrapper_name function to easily convert wrapper
-# name in many formats to the correct name of the wrapper class
-LOWER_TO_WRAPPER_NAME = {
-    'ascii2nc': 'ASCII2NC',
-    'cycloneplotter': 'CyclonePlotter',
-    'ensemblestat': 'EnsembleStat',
-    'example': 'Example',
-    'extracttiles': 'ExtractTiles',
-    'gempaktocf': 'GempakToCF',
-    'genvxmask': 'GenVxMask',
-    'genensprod': 'GenEnsProd',
-    'gfdltracker': 'GFDLTracker',
-    'griddiag': 'GridDiag',
-    'gridstat': 'GridStat',
-    'ioda2nc': 'IODA2NC',
-    'makeplots': 'MakePlots',
-    'metdbload': 'METDbLoad',
-    'mode': 'MODE',
-    'mtd': 'MTD',
-    'modetimedomain': 'MTD',
-    'pb2nc': 'PB2NC',
-    'pcpcombine': 'PCPCombine',
-    'plotdataplane': 'PlotDataPlane',
-    'plotpointobs': 'PlotPointObs',
-    'point2grid': 'Point2Grid',
-    'pointtogrid': 'Point2Grid',
-    'pointstat': 'PointStat',
-    'pyembedingest': 'PyEmbedIngest',
-    'regriddataplane': 'RegridDataPlane',
-    'seriesanalysis': 'SeriesAnalysis',
-    'statanalysis': 'StatAnalysis',
-    'tcgen': 'TCGen',
-    'tcpairs': 'TCPairs',
-    'tcrmw': 'TCRMW',
-    'tcstat': 'TCStat',
-    'tcmprplotter': 'TCMPRPlotter',
-    'usage': 'Usage',
-    'userscript': 'UserScript',
-}
+from . import LOWER_TO_WRAPPER_NAME
+
 
 def get_wrapper_name(process_name):
     """! Determine name of wrapper from string that may not contain the correct

--- a/metplus/util/met_util.py
+++ b/metplus/util/met_util.py
@@ -137,6 +137,7 @@ def run_metplus(config, process_list):
             return 1
 
         loop_order = config.getstr('config', 'LOOP_ORDER', '').lower()
+        loop_order = 'processes'
 
         if loop_order == "processes":
             all_commands = []

--- a/metplus/util/met_util.py
+++ b/metplus/util/met_util.py
@@ -136,22 +136,11 @@ def run_metplus(config, process_list):
             logger.info("Refer to ERROR messages above to resolve issues.")
             return 1
 
-        loop_order = config.getstr('config', 'LOOP_ORDER', '').lower()
-        #loop_order = 'processes'
-
-        if loop_order == "processes":
-            all_commands = []
-            for process in processes:
-                new_commands = process.run_all_times()
-                if new_commands:
-                    all_commands.extend(new_commands)
-
-        elif loop_order == "times":
-            all_commands = loop_over_times_and_call(config, processes)
-        else:
-            logger.error("Invalid LOOP_ORDER defined. "
-                         "Options are processes, times")
-            return 1
+        all_commands = []
+        for process in processes:
+            new_commands = process.run_all_times()
+            if new_commands:
+                all_commands.extend(new_commands)
 
         # if process list contains any wrapper that should run commands
         if any([item[0] not in NO_COMMAND_WRAPPERS for item in process_list]):

--- a/metplus/util/met_util.py
+++ b/metplus/util/met_util.py
@@ -137,7 +137,7 @@ def run_metplus(config, process_list):
             return 1
 
         loop_order = config.getstr('config', 'LOOP_ORDER', '').lower()
-        loop_order = 'processes'
+        #loop_order = 'processes'
 
         if loop_order == "processes":
             all_commands = []

--- a/metplus/util/met_util.py
+++ b/metplus/util/met_util.py
@@ -396,12 +396,6 @@ def write_final_conf(config):
 
         @param config METplusConfig object to write to file
      """
-    # write out os environment to file for debugging
-    env_file = os.path.join(config.getdir('LOG_DIR'), '.metplus_user_env')
-    with open(env_file, 'w') as env_file:
-        for key, value in os.environ.items():
-            env_file.write('{}={}\n'.format(key, value))
-
     final_conf = config.getstr('config', 'METPLUS_CONF')
 
     # remove variables that start with CURRENT

--- a/metplus/wrappers/command_builder.py
+++ b/metplus/wrappers/command_builder.py
@@ -88,10 +88,7 @@ class CommandBuilder:
             )
 
         self.instance = instance
-
-        self.env = os.environ.copy()
-        if hasattr(config, 'env'):
-            self.env = config.env
+        self.env = config.env if hasattr(config, 'env') else os.environ.copy()
 
         # populate c_dict dictionary
         self.c_dict = self.create_c_dict()

--- a/metplus/wrappers/command_builder.py
+++ b/metplus/wrappers/command_builder.py
@@ -1624,3 +1624,8 @@ class CommandBuilder:
 
         items['direct_prob'] = 'bool'
         self.add_met_config_dict('climo_cdf', items)
+
+    def get_wrapper_instance_name(self):
+        if not self.instance:
+            return self.app_name
+        return f'{self.app_name}({self.instance})'

--- a/metplus/wrappers/command_builder.py
+++ b/metplus/wrappers/command_builder.py
@@ -1278,16 +1278,6 @@ class CommandBuilder:
 
         return True
 
-    # argument needed to match call
-    # pylint:disable=unused-argument
-    def run_at_time(self, input_dict):
-        """! Used to output error and exit if wrapper is attempted to be run
-         with LOOP_ORDER = times and the run_at_time method is not implemented
-        """
-        self.log_error(f'run_at_time not implemented for {self.log_name} '
-                       'wrapper. Cannot run with LOOP_ORDER = times')
-        return None
-
     def run_all_times(self, custom=None):
         """! Loop over time range specified in conf file and
         call METplus wrapper for each time

--- a/metplus/wrappers/command_builder.py
+++ b/metplus/wrappers/command_builder.py
@@ -30,6 +30,7 @@ from ..util import get_custom_string_list
 from ..util import get_wrapped_met_config_file, add_met_config_item, format_met_config
 from ..util import remove_quotes
 from ..util import get_field_info, format_field_info
+from ..util import get_wrapper_name
 from ..util.met_config import add_met_config_dict, handle_climo_dict
 
 # pylint:disable=pointless-string-statement
@@ -1626,6 +1627,7 @@ class CommandBuilder:
         self.add_met_config_dict('climo_cdf', items)
 
     def get_wrapper_instance_name(self):
+        wrapper_name = get_wrapper_name(self.app_name)
         if not self.instance:
-            return self.app_name
-        return f'{self.app_name}({self.instance})'
+            return wrapper_name
+        return f'{wrapper_name}({self.instance})'

--- a/metplus/wrappers/grid_diag_wrapper.py
+++ b/metplus/wrappers/grid_diag_wrapper.py
@@ -152,26 +152,6 @@ class GridDiagWrapper(RuntimeFreqWrapper):
         return cmd
 
     def run_at_time_once(self, time_info):
-        """! Process runtime and try to build command to run ascii2nc
-             Args:
-                @param time_info dictionary containing timing information
-        """
-
-        # if custom is already set in time info, run for only that item
-        # if not, loop over the CUSTOM_LOOP_LIST and process once for each
-        if 'custom' in time_info:
-            custom_loop_list = [time_info['custom']]
-        else:
-            custom_loop_list = self.c_dict['CUSTOM_LOOP_LIST']
-
-        for custom_string in custom_loop_list:
-            if custom_string:
-                self.logger.info(f"Processing custom string: {custom_string}")
-
-            time_info['custom'] = custom_string
-            self.run_at_time_custom(time_info)
-
-    def run_at_time_custom(self, time_info):
         self.clear()
 
         # subset input files as appropriate

--- a/metplus/wrappers/make_plots_wrapper.py
+++ b/metplus/wrappers/make_plots_wrapper.py
@@ -105,7 +105,6 @@ class MakePlotsWrapper(CommandBuilder):
             self.config.getstr('config', 'LOG_MAKE_PLOTS_VERBOSITY',
                                c_dict['VERBOSITY'])
         )
-        c_dict['LOOP_ORDER'] = self.config.getstr('config', 'LOOP_ORDER')
         c_dict['INPUT_BASE_DIR'] = self.config.getdir('MAKE_PLOTS_INPUT_DIR')
         c_dict['OUTPUT_BASE_DIR'] = self.config.getdir('MAKE_PLOTS_OUTPUT_DIR')
         c_dict['SCRIPTS_BASE_DIR'] = self.config.getdir('MAKE_PLOTS_SCRIPTS_DIR')

--- a/metplus/wrappers/met_db_load_wrapper.py
+++ b/metplus/wrappers/met_db_load_wrapper.py
@@ -94,6 +94,9 @@ class METDbLoadWrapper(RuntimeFreqWrapper):
                 self.log_error(f"Must set MET_DB_LOAD_MV_{name}")
             c_dict[f'MV_{name}'] = value
 
+        # set variable to skip finding input files
+        c_dict['FIND_FILES'] = False
+
         return c_dict
 
     def get_command(self):

--- a/metplus/wrappers/plot_point_obs_wrapper.py
+++ b/metplus/wrappers/plot_point_obs_wrapper.py
@@ -14,10 +14,10 @@ import os
 
 from ..util import do_string_sub, ti_calculate, get_lead_sequence
 from ..util import skip_time
-from . import RuntimeFreqWrapper
+from . import LoopTimesWrapper
 
 
-class PlotPointObsWrapper(RuntimeFreqWrapper):
+class PlotPointObsWrapper(LoopTimesWrapper):
     """! Wrapper used to build commands to call plot_point_obs """
 
     WRAPPER_ENV_VAR_KEYS = [
@@ -55,10 +55,6 @@ class PlotPointObsWrapper(RuntimeFreqWrapper):
     def create_c_dict(self):
         c_dict = super().create_c_dict()
         app = self.app_name.upper()
-
-        # set default runtime frequency if unset explicitly
-        if not c_dict['RUNTIME_FREQ']:
-            c_dict['RUNTIME_FREQ'] = 'RUN_ONCE_FOR_EACH'
 
         c_dict['VERBOSITY'] = self.config.getstr('config',
                                                  f'LOG_{app}_VERBOSITY',

--- a/metplus/wrappers/plot_point_obs_wrapper.py
+++ b/metplus/wrappers/plot_point_obs_wrapper.py
@@ -70,8 +70,8 @@ class PlotPointObsWrapper(RuntimeFreqWrapper):
         c_dict['INPUT_DIR'] = self.config.getdir(f'{app}_INPUT_DIR', '')
 
         if not c_dict['INPUT_TEMPLATE']:
-            self.logger.warning(f'{app}_INPUT_TEMPLATE is required '
-                                'to run PlotPointObs wrapper.')
+            self.log_error(f'{app}_INPUT_TEMPLATE is required '
+                           'to run PlotPointObs wrapper.')
 
         # get optional grid input files
         c_dict['GRID_INPUT_TEMPLATE'] = self.config.getraw(

--- a/metplus/wrappers/runtime_freq_wrapper.py
+++ b/metplus/wrappers/runtime_freq_wrapper.py
@@ -514,14 +514,14 @@ class RuntimeFreqWrapper(CommandBuilder):
 
         if time_info.get('lead', '*') == '*':
             lead = 'ALL'
-        # use lead with letter if seconds cannot be computed e.g. 3m
-        elif time_info['valid'] == '*':
-            lead = time_util.ti_get_lead_string(time_info['lead'],
-                                                plural=False,
-                                                letter_only=True)
         else:
             lead = time_util.ti_get_seconds_from_lead(time_info['lead'],
                                                       time_info['valid'])
+        # use lead with letter if seconds cannot be computed e.g. 3m
+        if lead is None:
+            lead = time_util.ti_get_lead_string(time_info['lead'],
+                                                plural=False,
+                                                letter_only=True)
 
         return (f"{self.app_name}_files_{identifier}_"
                 f"init_{init}_valid_{valid}_lead_{lead}.txt")

--- a/metplus/wrappers/runtime_freq_wrapper.py
+++ b/metplus/wrappers/runtime_freq_wrapper.py
@@ -267,51 +267,15 @@ class RuntimeFreqWrapper(CommandBuilder):
 
         return success
 
-    def run_at_time(self, input_dict):
-        """! Runs the command for a given run time. This function loops
-              over the list of forecast leads and list of custom loops
-              and runs once for each combination
-
-            @param input_dict dictionary containing time information
-        """
-        # loop of forecast leads and process each
-        lead_seq = get_lead_sequence(self.config, input_dict)
-        for lead in lead_seq:
-            input_dict['lead'] = lead
-
-            # set current lead time config and environment variables
-            time_info = time_util.ti_calculate(input_dict)
-
-            self.logger.info(
-                f"Processing forecast lead {time_info['lead_string']}"
-            )
-
-            if skip_time(time_info, self.c_dict.get('SKIP_TIMES', {})):
-                self.logger.debug('Skipping run time')
-                continue
-
-            # since run_all_times was not called (LOOP_BY=times) then
-            # get files for current run time
-            file_dict = self.get_files_from_time(time_info)
-            all_files = []
-            if file_dict:
-                if isinstance(file_dict, list):
-                    all_files = file_dict
-                else:
-                    all_files = [file_dict]
-
-            self.c_dict['ALL_FILES'] = all_files
-
-            # Run for given init/valid time and forecast lead combination
-            self.clear()
-            self.run_at_time_once(time_info)
-
     def get_all_files(self, custom=None):
         """! Get all files that can be processed with the app.
         @returns A dictionary where the key is the type of data that was found,
         i.e. fcst or obs, and the value is a list of files that fit in that
         category
         """
+        if not self.c_dict.get('FIND_FILES', True):
+            return True
+
         self.logger.debug("Finding all input files")
         all_files = []
 
@@ -334,6 +298,9 @@ class RuntimeFreqWrapper(CommandBuilder):
         return True
 
     def get_all_files_from_leads(self, time_input):
+        if not self.c_dict.get('FIND_FILES', True):
+            return True
+
         lead_files = []
         # loop over all forecast leads
         wildcard_if_empty = self.c_dict.get('WILDCARD_LEAD_IF_EMPTY',
@@ -361,6 +328,9 @@ class RuntimeFreqWrapper(CommandBuilder):
         return lead_files
 
     def get_all_files_for_lead(self, time_input):
+        if not self.c_dict.get('FIND_FILES', True):
+            return True
+
         new_files = []
         for run_time in time_generator(self.config):
             if run_time is None:

--- a/metplus/wrappers/runtime_freq_wrapper.py
+++ b/metplus/wrappers/runtime_freq_wrapper.py
@@ -355,7 +355,8 @@ class RuntimeFreqWrapper(CommandBuilder):
 
         return new_files
 
-    def get_files_from_time(self, time_info):
+    @staticmethod
+    def get_files_from_time(time_info):
         """! Create dictionary containing time information (key time_info) and
              any relevant files for that runtime.
              @param time_info dictionary containing time information
@@ -366,7 +367,8 @@ class RuntimeFreqWrapper(CommandBuilder):
         file_dict['time_info'] = time_info.copy()
         return file_dict
 
-    def compare_time_info(self, runtime, filetime):
+    @staticmethod
+    def compare_time_info(runtime, filetime):
         """! Compare current runtime dictionary to current file time dictionary
              If runtime value for init, valid, or lead is not a wildcard and
              it doesn't match the file's time value, return False. Otherwise

--- a/metplus/wrappers/runtime_freq_wrapper.py
+++ b/metplus/wrappers/runtime_freq_wrapper.py
@@ -101,15 +101,6 @@ class RuntimeFreqWrapper(CommandBuilder):
                            f" {', '.join(self.FREQ_OPTIONS)}")
             return None
 
-        # if not running once for each runtime and loop order is not set to
-        # 'processes' report an error
-        if self.c_dict['RUNTIME_FREQ'] != 'RUN_ONCE_FOR_EACH':
-            loop_order = self.config.getstr('config', 'LOOP_ORDER', '').lower()
-            if loop_order != 'processes':
-                self.log_error(f"Cannot run using {self.c_dict['RUNTIME_FREQ']} "
-                               "mode unless LOOP_ORDER = processes")
-                return None
-
         wrapper_instance_name = self.get_wrapper_instance_name()
         self.logger.info(f'Running wrapper: {wrapper_instance_name}')
 

--- a/metplus/wrappers/runtime_freq_wrapper.py
+++ b/metplus/wrappers/runtime_freq_wrapper.py
@@ -414,7 +414,7 @@ class RuntimeFreqWrapper(CommandBuilder):
 
         return all_input_files
 
-    def subset_input_files(self, time_info, output_dir=None):
+    def subset_input_files(self, time_info, output_dir=None, leads=None):
         """! Obtain a subset of input files from the c_dict ALL_FILES based on
              the time information for the current run.
 
@@ -427,21 +427,34 @@ class RuntimeFreqWrapper(CommandBuilder):
         if not self.c_dict.get('ALL_FILES'):
             return all_input_files
 
-        for file_dict in self.c_dict['ALL_FILES']:
-            # compare time information for each input file
-            # add file to list of files to use if it matches
-            if not self.compare_time_info(time_info, file_dict['time_info']):
-                continue
+        if leads is None:
+            lead_loop = [None]
+        else:
+            lead_loop = leads
 
-            for input_key in file_dict:
-                # skip time info key
-                if input_key == 'time_info':
+        for file_dict in self.c_dict['ALL_FILES']:
+            for lead in lead_loop:
+                if lead is not None:
+                    current_time_info = time_info.copy()
+                    current_time_info['lead'] = lead
+                else:
+                    current_time_info = time_info
+
+                # compare time information for each input file
+                # add file to list of files to use if it matches
+                if not self.compare_time_info(current_time_info,
+                                              file_dict['time_info']):
                     continue
 
-                if input_key not in all_input_files:
-                    all_input_files[input_key] = []
+                for input_key in file_dict:
+                    # skip time info key
+                    if input_key == 'time_info':
+                        continue
 
-                all_input_files[input_key].extend(file_dict[input_key])
+                    if input_key not in all_input_files:
+                        all_input_files[input_key] = []
+
+                    all_input_files[input_key].extend(file_dict[input_key])
 
         # return None if no matching input files were found
         if not all_input_files:

--- a/metplus/wrappers/runtime_freq_wrapper.py
+++ b/metplus/wrappers/runtime_freq_wrapper.py
@@ -28,11 +28,12 @@ from ..util import time_generator, add_to_time_input
 class RuntimeFreqWrapper(CommandBuilder):
 
     # valid options for run frequency
-    FREQ_OPTIONS = ['RUN_ONCE',
-                    'RUN_ONCE_PER_INIT_OR_VALID',
-                    'RUN_ONCE_PER_LEAD',
-                    'RUN_ONCE_FOR_EACH'
-                    ]
+    FREQ_OPTIONS = [
+        'RUN_ONCE',
+        'RUN_ONCE_PER_INIT_OR_VALID',
+        'RUN_ONCE_PER_LEAD',
+        'RUN_ONCE_FOR_EACH'
+    ]
 
     def __init__(self, config, instance=None):
         super().__init__(config, instance=instance)

--- a/metplus/wrappers/runtime_freq_wrapper.py
+++ b/metplus/wrappers/runtime_freq_wrapper.py
@@ -110,6 +110,9 @@ class RuntimeFreqWrapper(CommandBuilder):
                                "mode unless LOOP_ORDER = processes")
                 return None
 
+        wrapper_instance_name = self.get_wrapper_instance_name()
+        self.logger.info(f'Running wrapper: {wrapper_instance_name}')
+
         # loop over all custom strings
         for custom_string in self.c_dict['CUSTOM_LOOP_LIST']:
             if custom_string:

--- a/metplus/wrappers/runtime_freq_wrapper.py
+++ b/metplus/wrappers/runtime_freq_wrapper.py
@@ -493,6 +493,11 @@ class RuntimeFreqWrapper(CommandBuilder):
 
         if time_info.get('lead', '*') == '*':
             lead = 'ALL'
+        # use lead with letter if seconds cannot be computed e.g. 3m
+        elif time_info['valid'] == '*':
+            lead = time_util.ti_get_lead_string(time_info['lead'],
+                                                plural=False,
+                                                letter_only=True)
         else:
             lead = time_util.ti_get_seconds_from_lead(time_info['lead'],
                                                       time_info['valid'])

--- a/metplus/wrappers/series_analysis_wrapper.py
+++ b/metplus/wrappers/series_analysis_wrapper.py
@@ -733,50 +733,6 @@ class SeriesAnalysisWrapper(RuntimeFreqWrapper):
 
         return True
 
-    @staticmethod
-    def _get_ascii_filename(data_type, storm_id, leads=None):
-        """! Build filename for ASCII file list file
-
-             @param data_type FCST, OBS, or BOTH
-             @param storm_id current storm ID or wildcard character
-             @param leads list of forecast leads to use add the forecast hour
-              string to the filename or the minimum and maximum forecast hour
-              strings if there are more than one lead
-             @returns string containing filename to use
-        """
-        prefix = f"{data_type}_FILES"
-
-        # of storm ID is set (not wildcard), then add it to filename
-        if storm_id == '*':
-            filename = ''
-        else:
-            filename = f"_{storm_id}"
-
-        # add forecast leads if specified
-        if leads is not None:
-            lead_hours_list = []
-            for lead in leads:
-                lead_hours = ti_get_hours_from_lead(lead)
-                if lead_hours is None:
-                    lead_hours = ti_get_lead_string(lead,
-                                                    letter_only=True)
-                lead_hours_list.append(lead_hours)
-
-            # get first forecast lead, convert to hours, and add to filename
-            lead_hours = min(lead_hours_list)
-
-            lead_str = str(lead_hours).zfill(3)
-            filename += f"_F{lead_str}"
-
-            # if list of forecast leads, get min and max and add them to name
-            if len(lead_hours_list) > 1:
-                max_lead_hours = max(lead_hours_list)
-                max_lead_str = str(max_lead_hours).zfill(3)
-                filename += f"_to_F{max_lead_str}"
-
-        ascii_filename = f"{prefix}{filename}"
-        return ascii_filename
-
     def get_output_dir(self, time_info, storm_id, label):
         """! Determine directory that will contain output data from the
               OUTPUT_DIR and OUTPUT_TEMPLATE. This will include any

--- a/metplus/wrappers/series_analysis_wrapper.py
+++ b/metplus/wrappers/series_analysis_wrapper.py
@@ -462,7 +462,7 @@ class SeriesAnalysisWrapper(RuntimeFreqWrapper):
             input_dict['init'] = '*'
             input_dict['valid'] = '*'
             lead_hours = [ti_get_lead_string(item, plural=False) for
-                              item in lead_group[1]]
+                          item in lead_group[1]]
 
             self.logger.debug(f"Processing {lead_group[0]} - forecast leads: "
                               f"{', '.join(lead_hours)}")

--- a/metplus/wrappers/series_analysis_wrapper.py
+++ b/metplus/wrappers/series_analysis_wrapper.py
@@ -461,11 +461,11 @@ class SeriesAnalysisWrapper(RuntimeFreqWrapper):
 
             input_dict['init'] = '*'
             input_dict['valid'] = '*'
-            lead_hours_str = [ti_get_lead_string(item, plural=False) for
+            lead_hours = [ti_get_lead_string(item, plural=False) for
                               item in lead_group[1]]
 
             self.logger.debug(f"Processing {lead_group[0]} - forecast leads: "
-                              f"{', '.join(lead_hours_str)}")
+                              f"{', '.join(lead_hours)}")
 
             self.c_dict['ALL_FILES'] = (
                 self.get_all_files_for_leads(input_dict, lead_group[1])

--- a/metplus/wrappers/stat_analysis_wrapper.py
+++ b/metplus/wrappers/stat_analysis_wrapper.py
@@ -158,7 +158,6 @@ class StatAnalysisWrapper(CommandBuilder):
             self.config.getstr('config', 'LOG_STAT_ANALYSIS_VERBOSITY',
                                c_dict['VERBOSITY'])
         )
-        c_dict['LOOP_ORDER'] = self.config.getstr('config', 'LOOP_ORDER')
 
         # STATAnalysis config file is optional, so
         # don't provide wrapped config file name as default value
@@ -436,7 +435,7 @@ class StatAnalysisWrapper(CommandBuilder):
         for missing_config in missing_config_list:
 
             # if running MakePlots
-            if (c_dict['LOOP_ORDER'] == 'processes' and self.runMakePlots):
+            if self.runMakePlots:
 
                 # if LINE_TYPE_LIST is missing, add it to group list
                 if missing_config == 'LINE_TYPE_LIST':

--- a/metplus/wrappers/tc_pairs_wrapper.py
+++ b/metplus/wrappers/tc_pairs_wrapper.py
@@ -285,7 +285,7 @@ class TCPairsWrapper(CommandBuilder):
                                 False)
         )
 
-        # if LOOP_ORDER = processes, only run once if True
+        # only run once if True
         c_dict['RUN_ONCE'] = self.config.getbool('config',
                                                  'TC_PAIRS_RUN_ONCE',
                                                  True)


### PR DESCRIPTION
Previously the RuntimeFreq wrappers (GridDiag, METDbLoad, SeriesAnalysis, UserScript, IODA2NC, PlotPointObs) gather all of the files needed for all runs, then subset the files for each run. This PR changes the logic to only get the files needed to run for each run. This is more consistent with how other wrappers behave and is the first step towards adding support for RuntimeFreq logic for all of the wrappers.

This PR also removes the logic that handles the LOOP_ORDER config variable so that the logic previously executed when `LOOP_ORDER = processes` is always executed. [This GHA run](https://github.com/dtcenter/METplus/actions/runs/3147036407) demonstrates that no differences (except for the mjo_enso:4 group that is a known difference) when forcing all existing use cases to run with `LOOP_ORDER = processes`.

Other cleanup involves being consistent with how custom looping is handled so it is all done in RuntimeFreq wrapper instead of being handled in each wrapper.

## Pull Request Testing ##

- [X] Describe testing already performed for these changes:</br>

Ran use cases and diff tests and made sure that the only differences were due to changes in the file_list filenames due to the changes in SeriesAnalysis wrapper to handle gathering files via RuntimeFreq wrapper instead of doing its own thing.

- [X] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

Review code changes for typos or obvious bugs
Ensure that the only failures in the automated tests are from the "Run Differences" step and only involve changing file names of file list files. Each file should be listed as "new output" and have a corresponding file that is listed as "previously in truth but no longer in output."

- [X] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**

- [X] Do these changes include sufficient testing updates? **[Yes]**

Updated the SeriesAnalysis unit tests to handle the new approach for getting files

- [X] Will this PR result in changes to the test suite? **[Yes]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

Some use case groups will have differences (file_list files only) that will require updating the develop-ref truth data.

- [X] Please complete this pull request review by **10/3/2022**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [X] Add any new Python packages to the [METplus Components Python Requirements](https://metplus.readthedocs.io/en/develop/Users_Guide/overview.html#metplus-components-python-requirements) table.
- [X] Review the source issue metadata (required labels, projects, and milestone).
- [X] Complete the PR definition above.
- [X] Ensure the PR title matches the feature or bugfix branch name.
- [X] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**
Select: **Organization** level software support **Project** or **Repository** level development cycle **Project**
Select: **Milestone** as the version that will include these changes
- [x] After submitting the PR, select **Development** with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub. **DON'T CLOSE ISSUE AFTER THIS PR**
