### PR TITLE
Bugfix develop Fix broken documentation links

### DIFF
--- a/docs/Users_Guide/index.rst
+++ b/docs/Users_Guide/index.rst
@@ -81,7 +81,7 @@ is sponsored by NSF.
    release-notes
    getting_started
    installation
-   configuration
+   systemconfiguration
    wrappers
    usecases
    quicksearch

--- a/docs/Users_Guide/systemconfiguration.rst
+++ b/docs/Users_Guide/systemconfiguration.rst
@@ -1054,6 +1054,11 @@ This example will run GridStatWrapper only.
 
 This example will run PCPCombineWrapper then GridStatWrapper.
 
+.. _process_list_instance_names:
+
+Instance Names in Process List
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Added in version 4.0.0 is the ability to specify an instance name for each
 process in the PROCESS_LIST. This allows multiple instances of the same
 wrapper to be specified in the PROCESS_LIST. Users can create a new section

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,3 @@
-sphinx-gallery
+sphinx-gallery==0.11.1
+sphinx==6.0.0
+sphinx-rtd-theme==1.2.0rc2


### PR DESCRIPTION
See #2003

Check that table of contents [+] icons are working properly: https://metplus.readthedocs.io/en/bugfix_develop_doc_links/Users_Guide/systemconfiguration.html