### PR TITLE
Bugfix #2070 main_v5.0 var list numeric order

### DIFF
--- a/internal/tests/pytests/util/config_metplus/test_config_metplus.py
+++ b/internal/tests/pytests/util/config_metplus/test_config_metplus.py
@@ -913,3 +913,18 @@ def test_format_var_items_options_semicolon(config_value,
     var_items = config_metplus._format_var_items(field_configs, time_info)
     result = var_items.get('extra')
     assert result == expected_result
+
+@pytest.mark.util
+def test_parse_var_list_double_digit(metplus_config):
+    """!This test ensures that parse_var_list returns field info in
+    numeric order (1,2,...,9,10,11) instead of alphabetical (1,10,11,2,3,etc)
+    """
+    config = metplus_config
+    for n in range(1, 12, 1):
+        config.set('config', f'FCST_VAR{n}_NAME', f'fcst_name{n}')
+        config.set('config', f'OBS_VAR{n}_NAME', f'obs_name{n}')
+
+    var_list = config_metplus.parse_var_list(config)
+    for n, var_item in enumerate(var_list, start=1):
+        assert var_item['fcst_name'] == f'fcst_name{n}'
+        assert var_item['obs_name'] == f'obs_name{n}'

--- a/metplus/util/config_metplus.py
+++ b/metplus/util/config_metplus.py
@@ -1099,7 +1099,7 @@ def parse_var_list(config, time_info=None, data_type=None, met_tool=None,
         if 'ens_output_name' in v.keys():
             config.logger.debug(" ens_output_name:"+v['ens_output_name'])
     '''
-    return sorted(var_list, key=lambda x: x['index'])
+    return sorted(var_list, key=lambda x: int(x['index']))
 
 def _find_var_name_indices(config, data_types, met_tool=None):
     data_type_regex = f"{'|'.join(data_types)}"


### PR DESCRIPTION
See #2072 for review instructions. Fixes issue in a less invasive approach to reduce the chance of unintended side effects.

NOTE: Failure in checks is a difference in surrogate severe use case output that is unrelated to these changes.