### PR TITLE
update out-of-date doc info about grouping forecast leads

### DIFF
--- a/docs/Users_Guide/glossary.rst
+++ b/docs/Users_Guide/glossary.rst
@@ -2330,7 +2330,7 @@ METplus Configuration Glossary
      | *Used by:*  SeriesAnalysis
 
    LEAD_SEQ_<n>_LABEL
-     Required when SERIES_BY_LEAD_GROUP_FCSTS=True. Specify the label of the corresponding bin of series by lead results.
+     Required if :term:`LEAD_SEQ_\<n>` is set. Specify the label of the nth forecast lead group .
 
      | *Used by:*  SeriesAnalysis
 
@@ -3742,7 +3742,7 @@ METplus Configuration Glossary
      .. warning:: **DEPRECATED:** Please use :term:`LEAD_SEQ_\<n>` and :term:`SERIES_ANALYSIS_RUNTIME_FREQ` instead.
 
    SERIES_BY_LEAD_GROUP_FCSTS
-     .. warning:: **DEPRECATED:** Please use :term:`SERIES_ANALYSIS_GROUP_FCSTS` instead.
+     .. warning:: **DEPRECATED:** Please use :term:`LEAD_SEQ_\<n>` and :term:`SERIES_ANALYSIS_RUNTIME_FREQ` instead.
 
    SERIES_CI
      .. warning:: **DEPRECATED:** Please use :term:`TCMPR_PLOTTER_SERIES_CI` instead.

--- a/docs/Users_Guide/systemconfiguration.rst
+++ b/docs/Users_Guide/systemconfiguration.rst
@@ -771,11 +771,8 @@ is equivalent to setting::
   [config]
   LEAD_SEQ = 0, 3, 6, 9, 12
 
-Grouping forecast leads is possible as well using a special version of
-the :term:`LEAD_SEQ` variable for the
-**SeriesByLead Wrapper Only**.
-If :term:`SERIES_BY_LEAD_GROUP_FCSTS` = True, then groups of
-forecast leads can be defined to be evaluated together.
+Groups of forecast leads can be defined to be evaluated together.
+**This applies to the SeriesAnalysis wrapper only**.
 Any number of these groups can be defined by setting
 configuration variables LEAD_SEQ_1, LEAD_SEQ_2, ..., :term:`LEAD_SEQ_\<n\>`.
 The value can be defined with a


### PR DESCRIPTION
Update to docs to correct info used in focus group assessment.

Please confirm that documentation changes are formatted properly.
https://metplus.readthedocs.io/en/bugfix_main_v5.0_doc_loop_leads/Users_Guide/systemconfiguration.html#lead-seq

