### PR TITLE
Upgrade to Python 3.10 for RTD documentation build to fix error from urllib3 (main_v5.0)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,10 +9,14 @@ version: 2
 #formats: all
 formats: [pdf]
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
 # Optionally set the version of Python and requirements required to build your
 # docs
 python:
-   version: 3.10
    install:
    - requirements: docs/requirements.txt
    - requirements: requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ formats: [pdf]
 # Optionally set the version of Python and requirements required to build your
 # docs
 python:
-   version: 3.8
+   version: 3.10
    install:
    - requirements: docs/requirements.txt
    - requirements: requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
 sphinx-gallery==0.11.1
 sphinx==5.3.0
 sphinx-rtd-theme==1.1.1
-urllib3==1.26.15

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx-gallery==0.11.1
 sphinx==5.3.0
 sphinx-rtd-theme==1.1.1
+urllib3==1.26.15


### PR DESCRIPTION
Ensure RTD runs do not fail.

This run from branch in this PR fixed the issue: https://readthedocs.org/projects/metplus/builds/20373588/