### PR TITLE
Release Guide - remove beta/rc tags/releases

### DIFF
--- a/docs/Release_Guide/release_steps/set_beta_deletion_reminder_official.rst
+++ b/docs/Release_Guide/release_steps/set_beta_deletion_reminder_official.rst
@@ -1,8 +1,12 @@
-Set up Reminder to Delete Beta Tags
------------------------------------
+Set up Reminder to Delete Beta/RC Tags and Releases
+---------------------------------------------------
 
-Help keep the GitHub repositories and DockerHub clean by removing beta tags.
-Do not delete the beta tags for this release right away.  Please set a
+Help keep the GitHub repositories and DockerHub clean by removing
+beta/rc tags and releases.
+Do not delete the tags/releases for this release right away.  Please set a
 calendar reminder or schedule an email to be sent two weeks from the release
-date as a reminder to delete the beta tags in both GitHub and DockerHub
-(if applicable).
+date as a reminder to delete the tags/releases.
+
+In GitHub, first delete all of the releases that contain beta or rc in the name,
+then delete all corresponding tags.
+Delete any beta/rc tags in DockerHub if applicable.


### PR DESCRIPTION
Review changes to Release Guide content. ReadTheDocs build did not trigger for this branch for some reason, but content can be viewed in 'Files changed' tab or downloaded from https://github.com/dtcenter/METplus/suites/15117675517/artifacts/863866143
