### PR TITLE
feature #2253 print error logs from conftest

### DIFF
--- a/internal/tests/pytests/conftest.py
+++ b/internal/tests/pytests/conftest.py
@@ -103,7 +103,15 @@ def metplus_config(request):
     config.logger = mock.MagicMock()
 
     yield config
-
+    
+    if config.logger.error.call_args_list:
+        err_msgs = [
+                str(msg.args[0]) 
+                for msg 
+                in config.logger.error.call_args_list
+                if len(msg.args) != 0]
+        print("Tests raised the following errors:")
+        print("\n".join(err_msgs))
     config.logger = old_logger
     # don't remove output base if test fails
     if request.node.rep_call.failed:


### PR DESCRIPTION
Adds functionality to conftest to print out any error logs captured by the mock logger. Only applies to wrapper tests that use `metplus_config` fixture.
This shouldn't cause any change in behaviour on successful test run, but is useful when developing tests and debugging test failures. On failed tests, where an error is logged from a wrapper, should produce output similar to the following in the test teardown:

```
---------------------------- Captured stdout setup -----------------------------
Parsing config file: /METplus/parm/metplus_config/defaults.conf
Parsing config file: /METplus/internal/tests/pytests/minimum_pytest.conf
Logging to /METplus/internal/tests/pytests/test_output/781808e5/logs/metplus.log
--------------------------- Captured stdout teardown ---------------------------
Tests raised the following errors:
(extract_tiles_wrapper.py:128) Must set FCST_EXTRACT_TILES_INPUT_DIR to run ExtractTiles wrapper
(extract_tiles_wrapper.py:140) FCST_EXTRACT_TILES_OUTPUT_TEMPLATE must be set.
(extract_tiles_wrapper.py:128) Must set OBS_EXTRACT_TILES_INPUT_DIR to run ExtractTiles wrapper
(extract_tiles_wrapper.py:140) OBS_EXTRACT_TILES_OUTPUT_TEMPLATE must be set.
(regrid_data_plane_wrapper.py:109) FCST_REGRID_DATA_PLANE_OUTPUT_TEMPLATE must be set if FCST_REGRID_DATA_PLANE_RUN is True
(regrid_data_plane_wrapper.py:131) OBS_REGRID_DATA_PLANE_OUTPUT_TEMPLATE must be set if OBS_REGRID_DATA_PLANE_RUN is True
(extract_tiles_wrapper.py:332) Could not find TC_STAT file: /METplus/internal/tests/pytests/input/filter_20141214.tcst
```


## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
Tested on passing and failing test runs to check behaviour.

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
Run tests and check there is no extraneous output.

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? 
Yes

- [x] Do these changes include sufficient testing updates?
Yes

- [x] Will this PR result in changes to the test suite? **[Yes or No]**</br>
Only on failed test runs that write an error to a wrapper logger.

- [x] Please complete this pull request review by **[Fill in date]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Add any new Python packages to the [METplus Components Python Requirements](https://metplus.readthedocs.io/en/develop/Users_Guide/overview.html#metplus-components-python-requirements) table.
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: @georgemccabe 
Select: 
Select: 
- [ ] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
