### PR TITLE
Bugfix #2762 part 2 -- fix PCPCombine leap year issue

### DIFF
--- a/metplus/wrappers/pcp_combine_wrapper.py
+++ b/metplus/wrappers/pcp_combine_wrapper.py
@@ -649,7 +649,7 @@ class PCPCombineWrapper(ReformatGriddedWrapper):
         accum_relative = get_relativedelta(accum, 'S')
         # using 1 hour for now
         smallest_input_accum = min(
-            [ti_get_seconds_from_relativedelta(lev['amount'], search_time)
+            [ti_get_seconds_from_relativedelta(lev['amount'], search_time - accum_relative)
              for lev in self.c_dict['ACCUM_DICT_LIST']]
         )
         if smallest_input_accum == 9999999:

--- a/ush/run_metplus.py
+++ b/ush/run_metplus.py
@@ -45,12 +45,6 @@ def main():
     if not config:
         return False
 
-    # warn if calling master_metplus.py
-    if basename(__file__) == 'master_metplus.py':
-        msg = ("master_metplus.py has been renamed to run_metplus.py. "
-               "This script name will be removed in a future version.")
-        config.logger.warning(msg)
-
     total_errors = run_metplus(config)
 
     return post_run_cleanup(config, 'METplus', total_errors)


### PR DESCRIPTION
## Pull Request Testing ##

- [X] Describe testing already performed for these changes:</br>

@CPKalb discovered that the previous PR #2764 still did not work for March of the use case. It did work for January and February. We debugged this together and discovered that the leap year was causing issues due to the way to the last time to look for accumulation data was calculated. This modification uses the valid time minus the total output accumulation as the reference time to compute the number of seconds of a year (input accum). We tested on Derecho with the use case and confirmed that it now works for all months.

- [X] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

Already done (see above)

- [X] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes or No]**

- [X] Do these changes include sufficient testing updates? **[Yes]**

We tested using the use case. Writing a useful unit test to make sure this behavior works would involve a lot of work and thought. We could consider adding this in the future, but it is out of the scope for this release.

- [X] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [X] Do these changes introduce new SonarQube findings? **[No]**</br>
If **yes**, please describe:

- [X] Please complete this pull request review by **11/4/2024**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [X] Add any new Python packages to the [METplus Components Python Requirements](https://metplus.readthedocs.io/en/develop/Users_Guide/appendixA.html#metplus-components-python-packages) table.
- [X] For any new datasets, an entry to the [METplus Verification Datasets Guide](https://metplus.readthedocs.io/en/latest/Verification_Datasets/index.html).
- [X] Review the source issue metadata (required labels, projects, and milestone).
- [X] Complete the PR definition above.
- [X] Ensure the PR title matches the feature or bugfix branch name.
- [X] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **Coordinated METplus-X.Y Support** project for bugfix releases or **METplus-Wrappers-X.Y.Z Development** project for official releases
- [X] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
