### PR TITLE
Feature #3054 develop scan_for_CVEs

### DIFF
--- a/.github/jobs/bash_functions.sh
+++ b/.github/jobs/bash_functions.sh
@@ -18,3 +18,19 @@ function time_command {
 
   return $error
 }
+
+# utility function to scan a Docker image for vulnerabilities
+function cve_scan_image {
+  echo "::group::Scanning image $1"
+  CMD_LOGFILE="${GITHUB_WORKSPACE}/CVE_Scan_`echo $1 | sed 's%[/,:]%_%g'`.log"
+  time_command grype $1
+  CMD_LOGFILE="${GITHUB_WORKSPACE}/CVE_Scan_`echo $1 | sed 's%[/,:]%_%g'`.log"
+  N_CRITICAL=`grep "Critical" ${CMD_LOGFILE} | wc -l`
+  if [ ${N_CRITICAL} -gt 0 ]; then
+    echo "WARNING: Found ${N_CRITICAL} Critical CVEs for image $1 in ${CMD_LOGFILE}"
+    echo
+    egrep "SEVERITY|Critical" ${CMD_LOGFILE}
+    echo
+  fi
+  echo "::endgroup::"
+}

--- a/.github/jobs/bash_functions.sh
+++ b/.github/jobs/bash_functions.sh
@@ -5,8 +5,18 @@
 function time_command {
   local start_seconds=$SECONDS
   echo "::group::RUNNING: $*"
-  "$@"
-  local error=$?
+
+  local error
+  # pipe output to log file if set
+  if [ "x$CMD_LOGFILE" == "x" ]; then
+    "$@"
+    error=$?
+  else
+    echo "Logging to ${CMD_LOGFILE}"
+    "$@" &>> $CMD_LOGFILE
+    error=$?
+    unset CMD_LOGFILE
+  fi
 
   local duration=$(( SECONDS - start_seconds ))
   echo "TIMING: Command took `printf '%02d' $(($duration / 60))`:`printf '%02d' $(($duration % 60))` (MM:SS): '$*'"

--- a/.github/jobs/bash_functions.sh
+++ b/.github/jobs/bash_functions.sh
@@ -21,7 +21,7 @@ function time_command {
 
 # utility function to scan a Docker image for vulnerabilities
 function cve_scan_image {
-  echo "::group::Scanning image $1"
+  echo "Scanning image $1"
   CMD_LOGFILE="${GITHUB_WORKSPACE}/CVE_Scan_`echo $1 | sed 's%[/,:]%_%g'`.log"
   time_command grype $1
   CMD_LOGFILE="${GITHUB_WORKSPACE}/CVE_Scan_`echo $1 | sed 's%[/,:]%_%g'`.log"
@@ -32,5 +32,4 @@ function cve_scan_image {
     egrep "SEVERITY|Critical" ${CMD_LOGFILE}
     echo
   fi
-  echo "::endgroup::"
 }

--- a/.github/jobs/docker_build_metplus_images.sh
+++ b/.github/jobs/docker_build_metplus_images.sh
@@ -23,7 +23,7 @@ echo "$met_tag"
 
 MET_DOCKER_REPO=met
 if [ "$met_tag" == "develop" ] || [[ "${met_tag}" =~ ^main_v[0-9]+\.[0-9]+ ]]; then
-    MET_DOCKER_REPO=met-dev
+  MET_DOCKER_REPO=met-dev
 fi
 
 # get METplus Analysis tool versions

--- a/.github/jobs/docker_build_metplus_images.sh
+++ b/.github/jobs/docker_build_metplus_images.sh
@@ -7,12 +7,6 @@ source "${GITHUB_WORKSPACE}"/.github/jobs/bash_functions.sh
 dockerhub_repo=dtcenter/metplus
 dockerhub_repo_analysis=dtcenter/metplus-analysis
 
-# check if tag is official or bugfix release -- no -betaN or -rcN suffix
-is_official=1
-if [[ "${SOURCE_BRANCH}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  is_official=0
-fi
-
 # remove v prefix
 metplus_version=${SOURCE_BRANCH:1}
 
@@ -58,12 +52,4 @@ if ! time_command docker build -t "$METPLUS_A_IMAGE_NAME" \
        -f "${GITHUB_WORKSPACE}"/internal/scripts/docker/Dockerfile.metplus-analysis \
        "${GITHUB_WORKSPACE}"; then
     exit 1
-fi
-
-# if official release, create X.Y-latest tag as well
-if [ "${is_official}" == 0 ]; then
-    LATEST_TAG=$(echo "$metplus_version" | cut -f1,2 -d'.')-latest
-    docker tag "${METPLUS_IMAGE_NAME}" "${dockerhub_repo}:${LATEST_TAG}"
-    docker tag "${METPLUS_A_IMAGE_NAME}" "${dockerhub_repo_analysis}:${LATEST_TAG}"
-    echo LATEST_TAG="${LATEST_TAG}" >> "$GITHUB_OUTPUT"
 fi

--- a/.github/jobs/docker_push_metplus_images.sh
+++ b/.github/jobs/docker_push_metplus_images.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # assumes SOURCE_BRANCH is set before calling script
-# assumes latest_tag will be set if pushing an official or bugfix release
 
 source "${GITHUB_WORKSPACE}"/.github/jobs/bash_functions.sh
 
@@ -34,13 +33,24 @@ if ! time_command docker push "${METPLUS_A_IMAGE_NAME}"; then
   exit 1
 fi
 
-# only push X.Y-latest tag if official or bugfix release
+# only push X.Y-latest tag if requested for official or bugfix releases
 # shellcheck disable=SC2154
-if [ "${LATEST_TAG}" != "" ]; then
-    if ! time_command docker push "${dockerhub_repo}:${LATEST_TAG}"; then
-      exit 1
-    fi
-    if ! time_command docker push "${dockerhub_repo_analysis}:${LATEST_TAG}"; then
-      exit 1
-    fi
+if [[ "${UPDATE_LATEST}" == "true" && "${SOURCE_BRANCH}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  latest_version=$(echo ${metplus_version} | cut -f1,2 -d'.')-latest
+
+  # tag and push the METplus image  
+  if ! time_command docker tag ${METPLUS_IMAGE_NAME} "${dockerhub_repo}:${latest_version}"; then
+    exit 1
+  fi
+  if ! time_command docker push "${dockerhub_repo}:${latest_version}"; then
+    exit 1
+  fi
+
+  # tag and push the METplus Analysis image
+  if ! time_command docker tag ${METPLUS_A_IMAGE_NAME} "${dockerhub_repo_analysis}:${latest_version}"; then
+    exit 1
+  fi
+  if ! time_command docker push "${dockerhub_repo_analysis}:${latest_version}"; then
+    exit 1
+  fi
 fi

--- a/.github/jobs/docker_push_metplus_images.sh
+++ b/.github/jobs/docker_push_metplus_images.sh
@@ -17,8 +17,8 @@ METPLUS_A_IMAGE_NAME=${dockerhub_repo_analysis}:${metplus_version}
 
 # skip docker push if credentials are not set
 if [ -z ${DOCKER_USERNAME+x} ] || [ -z ${DOCKER_PASSWORD+x} ]; then
-    echo "DockerHub credentials not set. Skipping docker push"
-    exit 0
+  echo "DockerHub credentials not set. Skipping docker push"
+  exit 0
 fi
 
 echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin

--- a/.github/jobs/docker_scan_metplus_images.sh
+++ b/.github/jobs/docker_scan_metplus_images.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# assumes SOURCE_BRANCH is set before calling script
+
+source "${GITHUB_WORKSPACE}"/.github/jobs/bash_functions.sh
+
+# get names of images to push
+
+dockerhub_repo=dtcenter/metplus
+dockerhub_repo_analysis=dtcenter/metplus-analysis
+
+# remove v prefix
+metplus_version=${SOURCE_BRANCH:1}
+
+METPLUS_IMAGE_NAME=${dockerhub_repo}:${metplus_version}
+METPLUS_A_IMAGE_NAME=${dockerhub_repo_analysis}:${metplus_version}
+
+# Scan the images
+cve_scan_image ${METPLUS_IMAGE_NAME}
+cve_scan_image ${METPLUS_A_IMAGE_NAME}
+

--- a/.github/jobs/docker_scan_metplus_images.sh
+++ b/.github/jobs/docker_scan_metplus_images.sh
@@ -18,4 +18,3 @@ METPLUS_A_IMAGE_NAME=${dockerhub_repo_analysis}:${metplus_version}
 # Scan the images
 cve_scan_image ${METPLUS_IMAGE_NAME}
 cve_scan_image ${METPLUS_A_IMAGE_NAME}
-

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -63,7 +63,7 @@ jobs:
           ref: ${{ matrix.version }}
           path: ${{ matrix.version }}
           sparse-checkout: internal/scripts/docker
-          sparse-checkout-cont-mode: false
+          sparse-checkout-cone-mode: false
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -1,49 +1,120 @@
-name: Create Docker images for release
+name: Create Release Docker Images
 
 on:
+
   release:
     types:
       - published
+
   workflow_dispatch:
     inputs:
-      version:
-        description: 'vX.Y.Z version of METplus to rebuild, e.g. v6.0.0'
+      release_version:
+        description: 'Comma-separated list of versions to build, e.g. "v6.0.0","v6.1.0"'
+        default: '"v6.0.0"'
         required: true
+        type: string
+      update_latest:
+        description: 'For "vX.Y.Z" versions, update the corresponding "X.Y-latest" images.'
+        default: false
+        required: true
+        type: boolean
+
+  schedule:
+    - cron: "30 06 * * 0"
 
 jobs:
-  build_and_push:
-    name: Build and Push Images
+
+  define-matrix:
+    name: Define Matrix
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.get-versions.outputs.matrix }}
+      update_latest: ${{ steps.get-versions.outputs.update_latest }}
+
+    steps:
+      - name: Get versions to build 
+        id: get-versions
+        run: |
+          if [[ ${{ github.event_name }} == 'schedule' ]]; then
+            version_list="\"v6.0.0\""
+            update_latest="true"
+          elif [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
+            version_list=${{ toJSON(inputs.release_version) }}
+            update_latest=${{ toJSON(inputs.update_latest) }}
+          else
+            version_list=\"${{ toJSON(github.ref_name) }}\"
+            update_latest="true"
+          fi
+          echo "matrix={\"version\": [ ${version_list} ]}" >> $GITHUB_OUTPUT
+          echo "update_latest=${update_latest}" >> $GITHUB_OUTPUT
+ 
+  build_scan_and_push:
+    name: Build, Scan, and Push Images
+    runs-on: ubuntu-latest
+    needs: define-matrix
+    strategy:
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.version }}
+          path: ${{ matrix.version }}
+          sparse-checkout: internal/scripts/docker
+          sparse-checkout-cont-mode: false
+
       - uses: actions/checkout@v4
         with:
           ref: 'develop'
           path: 'develop'
           sparse-checkout: metplus/component_versions.py
           sparse-checkout-cone-mode: false
-      - name: Get and check tag name
-        id: get_tag_name
+
+      - name: Create directories to store output
         run: |
-          if [ ${{ github.event_name != 'workflow_dispatch' }} ]; then
-            SOURCE_BRANCH=${{ github.event.inputs.version }}
-          else
-            SOURCE_BRANCH=${GITHUB_REF#refs/tags/}
-          fi
-          if [[ ! "${SOURCE_BRANCH}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            echo "ERROR: Tag name (${SOURCE_BRANCH}) does not start with vX.Y.Z format"
-            exit 1
-          fi
-          echo SOURCE_BRANCH=${SOURCE_BRANCH} >> $GITHUB_OUTPUT
-      - name: Build metplus and metplus-analysis images
+          mkdir -p ${RUNNER_WORKSPACE}/logs
+
+      - name: Build Docker Images
         id: build_images
         run: .github/jobs/docker_build_metplus_images.sh
         env:
-          SOURCE_BRANCH: ${{ steps.get_tag_name.outputs.SOURCE_BRANCH }}
-      - name: Push metplus and metplus-analysis images
-        run: .github/jobs/docker_push_metplus_images.sh
+          SOURCE_BRANCH: ${{ matrix.version }}
+
+      - name: Install Syft
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+
+      - name: Install Grype
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+
+      - name: Scan Docker Images
+        run: |
+          .github/jobs/docker_scan_metplus_images.sh
         env:
-          SOURCE_BRANCH: ${{ steps.get_tag_name.outputs.SOURCE_BRANCH }}
-          LATEST_TAG: ${{ steps.build_images.outputs.LATEST_TAG }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          SOURCE_BRANCH: ${{ matrix.version }}
+
+      - name: Push Docker Images
+        run: |
+          .github/jobs/docker_push_metplus_images.sh
+        env:
+          SOURCE_BRANCH: ${{ matrix.version }}
+          UPDATE_LATEST: ${{ fromJSON(needs.define-matrix.outputs.update_latest) }}
+          DOCKER_USERNAME: 'dtcenter'
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Copy log files into logs directory
+        if: always()
+        run: |
+          cp ${GITHUB_WORKSPACE}/*.log ${RUNNER_WORKSPACE}/logs/
+
+      - name: Upload logs as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs_${{ matrix.version }}
+          path: ${{ runner.workspace }}/logs
+          if-no-files-found: ignore
+

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -10,7 +10,7 @@ on:
     inputs:
       release_version:
         description: 'Comma-separated list of versions to build, e.g. "v6.0.0","v6.1.0"'
-        default: '"v6.0.0"'
+        default: '"v6.1.0"'
         required: true
         type: string
       update_latest:
@@ -36,7 +36,7 @@ jobs:
         id: get-versions
         run: |
           if [[ ${{ github.event_name }} == 'schedule' ]]; then
-            version_list="\"v6.0.0\""
+            version_list="\"v6.0.0\",\"v6.1.0\""
             update_latest="true"
           elif [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
             version_list=${{ toJSON(inputs.release_version) }}
@@ -117,4 +117,3 @@ jobs:
           name: logs_${{ matrix.version }}
           path: ${{ runner.workspace }}/logs
           if-no-files-found: ignore
-

--- a/docs/Contributors_Guide/continuous_integration.rst
+++ b/docs/Contributors_Guide/continuous_integration.rst
@@ -973,11 +973,11 @@ environments use this environment as a base.
 * Python 3.12.0
 * matplotlib 3.10.0
 * scipy 1.15.1
-* plotly 6.0.0
+* plotly 6.1.1
 * xarray 2025.1.2
 * netcdf4 1.7.2
 * pyyaml 6.0.2
-* python-kaleido 0.2.1
+* python-kaleido 1.0.0 
 * imageio 2.37.0
 * imutils 0.5.4
 * scikit-image 0.25.1

--- a/docs/Release_Guide/met_bugfix.rst
+++ b/docs/Release_Guide/met_bugfix.rst
@@ -10,6 +10,7 @@ Create a new vX.Y.Z bugfix release from the main_vX.Y branch.
 .. include:: release_steps/checkout_main_branch.rst
 .. include:: release_steps/create_release_feature_branch.rst
 .. include:: release_steps/met/update_version_bugfix.rst
+.. include:: release_steps/update_docker_image_workflow.rst
 .. include:: release_steps/update_release_notes_bugfix.rst
 .. include:: release_steps/merge_release_issue.rst
 .. include:: release_steps/create_release_on_github.rst

--- a/docs/Release_Guide/met_official.rst
+++ b/docs/Release_Guide/met_official.rst
@@ -10,6 +10,7 @@ Create a new vX.Y.Z official release from the develop branch.
 .. include:: release_steps/checkout_main_branch.rst
 .. include:: release_steps/create_release_feature_branch.rst
 .. include:: release_steps/met/update_version_official.rst
+.. include:: release_steps/update_docker_image_workflow.rst
 .. include:: release_steps/update_release_notes_official.rst
 .. include:: release_steps/update_upgrade_instructions.rst
 .. include:: release_steps/rotate_authorship.rst

--- a/docs/Release_Guide/metplus_bugfix.rst
+++ b/docs/Release_Guide/metplus_bugfix.rst
@@ -10,6 +10,7 @@ Create a new vX.Y.Z bugfix release from the main_vX.Y branch.
 .. include:: release_steps/checkout_main_branch.rst
 .. include:: release_steps/create_release_feature_branch.rst
 .. include:: release_steps/metplus/update_version_bugfix.rst
+.. include:: release_steps/update_docker_image_workflow.rst
 .. include:: release_steps/update_release_notes_bugfix.rst
 .. include:: release_steps/metplus/update_existing_builds_docker.rst
 .. include:: release_steps/merge_release_issue.rst

--- a/docs/Release_Guide/metplus_official.rst
+++ b/docs/Release_Guide/metplus_official.rst
@@ -10,6 +10,7 @@ Create a new vX.Y.Z official release from the develop branch.
 .. include:: release_steps/checkout_main_branch.rst
 .. include:: release_steps/create_release_feature_branch.rst
 .. include:: release_steps/metplus/update_version_official.rst
+.. include:: release_steps/update_docker_image_workflow.rst
 .. include:: release_steps/metplus/update_release_date.rst
 .. include:: release_steps/update_release_notes_official.rst
 .. include:: release_steps/update_upgrade_instructions.rst

--- a/docs/Release_Guide/metviewer_bugfix.rst
+++ b/docs/Release_Guide/metviewer_bugfix.rst
@@ -10,6 +10,7 @@ Create a new vX.Y.Z bugfix release from the main_vX.Y branch.
 .. include:: release_steps/checkout_main_branch.rst
 .. include:: release_steps/create_release_feature_branch.rst
 .. include:: release_steps/metviewer/update_version_bugfix.rst
+.. include:: release_steps/update_docker_image_workflow.rst
 .. include:: release_steps/update_release_notes_bugfix.rst
 .. include:: release_steps/merge_release_issue.rst
 .. include:: release_steps/create_release_on_github.rst

--- a/docs/Release_Guide/metviewer_official.rst
+++ b/docs/Release_Guide/metviewer_official.rst
@@ -10,6 +10,7 @@ Create a new vX.Y.Z official release from the develop branch.
 .. include:: release_steps/checkout_main_branch.rst
 .. include:: release_steps/create_release_feature_branch.rst
 .. include:: release_steps/metviewer/update_version_official.rst
+.. include:: release_steps/update_docker_image_workflow.rst
 .. include:: release_steps/update_release_notes_official.rst
 .. include:: release_steps/update_upgrade_instructions.rst
 .. include:: release_steps/rotate_authorship.rst

--- a/docs/Release_Guide/release_steps/update_docker_image_workflow.rst
+++ b/docs/Release_Guide/release_steps/update_docker_image_workflow.rst
@@ -11,8 +11,11 @@ Update the list of versions whose Docker images should be rebuilt on schedule.
 
   * In the 'define-matrix' job, update the 'version_list' for **schedule** events:
 
-    * Add this new vX.Y.Z version to the list of versions.
+    * Add the new vX.Y.Z version to the list of versions.
 
-    * For bugfix releases, consider removing the previous bugfix version, e.g. vX.Y.Z-1.
+    * For bugfix releases, remove the previous bugfix version, e.g. vX.Y.Z-1. 
+      The scheduled runs of this workflow update the Docker Hub 'X.Y-latest' tags.
+      Only the most recent 'vX.Y.Z' bugfix release should be listed to avoid ambiguity
+      when updating 'X.Y-latest' tags. 
 
     * For official releases, remove earlier versions only if their support has ended. 

--- a/docs/Release_Guide/release_steps/update_docker_image_workflow.rst
+++ b/docs/Release_Guide/release_steps/update_docker_image_workflow.rst
@@ -5,11 +5,11 @@ Update the list of versions whose Docker images should be rebuilt on schedule.
 
 .. dropdown:: Instructions
 
-  * The **Create Release Docker Images** workflow is defined in **.github/workflows/release-docker-images.yml**.
+  * The **Create Release Docker Images** workflow is defined in '.github/workflows/release-docker-images.yml'.
 
-  * In the **workflow_dispatch** section, consider updating the *default* **release_version** to be built.
+  * In the 'workflow_dispatch' section, consider updating the *default* 'release_version' to be built.
 
-  * In the **define-matrix** job, update the **version_list** for **schedule** events:
+  * In the 'define-matrix' job, update the 'version_list' for **schedule** events:
 
     * Add this new vX.Y.Z version to the list of versions.
 

--- a/docs/Release_Guide/release_steps/update_docker_image_workflow.rst
+++ b/docs/Release_Guide/release_steps/update_docker_image_workflow.rst
@@ -1,0 +1,18 @@
+Update Docker Image Workflow
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Update the list of versions whose Docker images should be rebuilt on schedule.
+
+.. dropdown:: Instructions
+
+  * The **Create Release Docker Images** workflow is defined in **.github/workflows/release-docker-images.yml**.
+
+  * In the **workflow_dispatch** section, consider updating the *default* **release_version** to be built.
+
+  * In the **define-matrix** job, update the **version_list** for **schedule** events:
+
+    * Add this new vX.Y.Z version to the list of versions.
+
+    * For bugfix releases, consider removing the previous bugfix version, e.g. vX.Y.Z-1.
+
+    * For official releases, remove earlier versions only if their support has ended. 

--- a/docs/Release_Guide/release_steps/update_docker_image_workflow.rst
+++ b/docs/Release_Guide/release_steps/update_docker_image_workflow.rst
@@ -14,8 +14,7 @@ Update the list of versions whose Docker images should be rebuilt on schedule.
     * Add the new vX.Y.Z version to the list of versions.
 
     * For bugfix releases, remove the previous bugfix version, e.g. vX.Y.Z-1. 
-      The scheduled runs of this workflow update the Docker Hub 'X.Y-latest' tags.
-      Only the most recent 'vX.Y.Z' bugfix release should be listed to avoid ambiguity
-      when updating 'X.Y-latest' tags. 
+      Only the most recent 'vX.Y.Z' bugfix version for each 'vX.Y' release can
+      be listed to avoid ambiguity when updating 'X.Y-latest' tags on Docker Hub.
 
     * For official releases, remove earlier versions only if their support has ended. 

--- a/docs/Users_Guide/appendixA.rst
+++ b/docs/Users_Guide/appendixA.rst
@@ -317,7 +317,7 @@ METplus Components Python Packages
   Description:
     Python package to define, operate and manipulate physical quantities
 
-.. dropdown:: plotly >=5.13.0
+.. dropdown:: plotly >=6.1.1
 
   METplus Component: 
     | METcalcpy, 
@@ -423,7 +423,7 @@ METplus Components Python Packages
   Description:
     A mature full-featured Python testing tool that helps to write better programs
 
-.. dropdown:: python-kaleido >=0.2.1
+.. dropdown:: python-kaleido >=1.0.0
 
   METplus Component:
     | METcalcpy, 

--- a/internal/scripts/docker_env/scripts/metplotpy_env.sh
+++ b/internal/scripts/docker_env/scripts/metplotpy_env.sh
@@ -2,16 +2,19 @@
 
 ################################################################################
 # Environment: metplotpy.v6.1
-# Last Updated: 2025-02-05 (mccabe@ucar.edu)
-# Notes: Adds Python packages needed to run METplotpy and METcalcpy
+# Updated: 2025-07-16 (johnhg@ucar.edu)
+#   Increases plotly version from 6.0.0 to 6.1.1
+#   Increases kaleido version from 0.2.1 to 1.0.0
+# Updated: 2025-02-05 (mccabe@ucar.edu)
+#   Adds Python packages needed to run METplotpy and METcalcpy
 # Python Packages:
 #   matplotlib==3.10.0
 #   scipy==1.15.1
-#   plotly==6.0.0
+#   plotly==6.1.1
 #   xarray==2025.1.2
 #   netcdf4==1.7.2
 #   pyyaml==6.0.2
-#   python-kaleido==0.2.1
+#   python-kaleido==1.0.0
 #   imageio==2.37.0
 #   imutils==0.5.4
 #   scikit-image==0.25.1
@@ -36,11 +39,11 @@ conda create -y --clone ${BASE_ENV} --name ${ENV_NAME}
 mamba install -y --name ${ENV_NAME} -c conda-forge \
   matplotlib==3.10.0 \
   scipy==1.15.1 \
-  plotly==6.0.0 \
+  plotly==6.1.1 \
   xarray==2025.1.2 \
   netcdf4==1.7.2 \
   pyyaml==6.0.2 \
-  python-kaleido==0.2.1 \
+  python-kaleido==1.0.0 \
   imageio==2.37.0 \
   imutils==0.5.4 \
   scikit-image==0.25.1 \

--- a/internal/scripts/installation/metplus_components_v6.1_py3.12.sh
+++ b/internal/scripts/installation/metplus_components_v6.1_py3.12.sh
@@ -7,12 +7,12 @@ ${MINICONDA_PATH}/bin/conda create -y --name ${ENV_NAME} -c conda-forge python=3
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge python-dateutil==2.9.0.post0
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge matplotlib==3.10.3
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge scipy==1.15.1
-${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge plotly==6.0.0
+${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge plotly==6.1.1
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge xarray==2025.1.2
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge netcdf4==1.7.2
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge pyyaml==6.0.2
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge statsmodels
-${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge python-kaleido==0.2.1
+${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge python-kaleido==1.0.0
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge imageio==2.37.0
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge imutils==0.5.4
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge scikit-image==0.25.1

--- a/internal/scripts/installation/metplus_components_v6.1_py3.12.sh
+++ b/internal/scripts/installation/metplus_components_v6.1_py3.12.sh
@@ -7,12 +7,12 @@ ${MINICONDA_PATH}/bin/conda create -y --name ${ENV_NAME} -c conda-forge python=3
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge python-dateutil==2.9.0.post0
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge matplotlib==3.10.3
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge scipy==1.15.1
-${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge plotly==6.1.1
+${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge plotly==6.0.0
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge xarray==2025.1.2
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge netcdf4==1.7.2
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge pyyaml==6.0.2
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge statsmodels
-${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge python-kaleido==1.0.0
+${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge python-kaleido==0.2.1
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge imageio==2.37.0
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge imutils==0.5.4
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge scikit-image==0.25.1


### PR DESCRIPTION
## Pull Request Testing ##

This PR proposes enhancements to the `develop` branch to add CVE scanning to the existing `release-docker-images.yml` workflow. The 12 modified files include changes for:
- [1] `bash_functions.sh` to add the `cve_scan_image` function and enhance the existing `time_command` function to redirect log output to a file which is already supported in MET and METviewer.
- [1] `docker_build_metplus_images.sh` removes the `is_official` variable and move the handling of `X.Y-latest` images from here to `docker_push_metplus_images.sh`.
- [1] `docker_push_metplus_images.sh` adds logic for handling `X.Y-latest` images.
- [1] `docker_scan_metplus_images.sh` is new and calls the `cve_scan_image` to run grype on the 2 METplus images and write the result to a log file.
- [1] `release-docker-images.yml` workflow can now be run for new releases, through workflow_dispatch, and on a cron schedule (3 hours after the MET cron is run weekly). The `define-matrix` job is new to handle building images for multiple versions. And Syft/Grype are installed to support the new scanning step. Note that this is updated to reference the new `DOCKER_TOKEN` repository secret rather than building/pushing as @georgemccabe.
- [7] The `Release_Guide` docs are updated by adding new instructions for updating the Docker image workflow in `update_docker_image_workflow.rst`. And then those instructions are referenced in the official and bugfix instructions for MET, METplus, and METviewer.

- [x] Describe testing already performed for these changes:</br>
Manually ran the updated `release-docker-images.yml` workflow in [this GHA run](https://github.com/dtcenter/METplus/actions/runs/16325025709), and confirmed that it ran as expected and produced the expected scanning results. I downloaded/inspected the error logs and found that all errors are based on the METplus-Analysis tools problem with kaleido:
```
egrep -i ERROR `find ./ -name "*.log"` | grep kaleido
.//s2s/UserScript_obsPrecip_obsOnly_Hovmoeller/user_script.log:AttributeError: module 'kaleido' has no attribute 'get_chrome_sync'
.//clouds/GridStat_fcstGFS_obsGFS_cloudFracLayer/user_script.plot_stats.log:AttributeError: module 'kaleido' has no attribute 'get_chrome_sync'
.//tc_and_extra_tc/PointStat_fcstWRF_obsMADIS_hurricane_matthew/user_script.metplotpy.log:AttributeError: module 'kaleido' has no attribute 'get_chrome_sync'
.//s2s_soil_moisture/GridStat_fcstSFSGSL_obsERA5Land_SoilMoisture/user_script.plot_stats.log:AttributeError: module 'kaleido' has no attribute 'get_chrome_sync'
```
- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
Review code changes, the output of the run linked above, and the Release Guide updates.

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**

- [x] Do these changes include sufficient testing updates? **[No]**
None needed.

- [x] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

Note however that 4 of the METplus use cases failed in this [GHA Pull Request testing workflow run](https://github.com/dtcenter/METplus/actions/runs/16326169537).


- [x] Do these changes introduce new SonarQube findings? **[No]**</br>
If **yes**, please describe:

- [x] Please complete this pull request review by **[Thurs July 17, 2025]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Add any new Python packages to the [METplus Components Python Requirements](https://metplus.readthedocs.io/en/develop/Users_Guide/appendixA.html#metplus-components-python-packages) table.
- [x] For any new datasets, an entry to the [METplus Verification Datasets Guide](https://metplus.readthedocs.io/en/latest/Verification_Datasets/index.html).
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **Coordinated METplus-X.Y Support** project for bugfix releases or **METplus-Wrappers-X.Y.Z Development** project for official releases
- [x] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
