### PR TITLE
Feature #3054 main_v6.1 scan_for_CVEs

### DIFF
--- a/.github/jobs/bash_functions.sh
+++ b/.github/jobs/bash_functions.sh
@@ -5,8 +5,18 @@
 function time_command {
   local start_seconds=$SECONDS
   echo "::group::RUNNING: $*"
-  "$@"
-  local error=$?
+
+  local error
+  # pipe output to log file if set
+  if [ "x$CMD_LOGFILE" == "x" ]; then
+    "$@"
+    error=$?
+  else
+    echo "Logging to ${CMD_LOGFILE}"
+    "$@" &>> $CMD_LOGFILE
+    error=$?
+    unset CMD_LOGFILE
+  fi
 
   local duration=$(( SECONDS - start_seconds ))
   echo "TIMING: Command took `printf '%02d' $(($duration / 60))`:`printf '%02d' $(($duration % 60))` (MM:SS): '$*'"
@@ -17,4 +27,19 @@ function time_command {
   fi
 
   return $error
+}
+
+# utility function to scan a Docker image for vulnerabilities
+function cve_scan_image {
+  echo "Scanning image $1"
+  CMD_LOGFILE="${GITHUB_WORKSPACE}/CVE_Scan_`echo $1 | sed 's%[/,:]%_%g'`.log"
+  time_command grype $1
+  CMD_LOGFILE="${GITHUB_WORKSPACE}/CVE_Scan_`echo $1 | sed 's%[/,:]%_%g'`.log"
+  N_CRITICAL=`grep "Critical" ${CMD_LOGFILE} | wc -l`
+  if [ ${N_CRITICAL} -gt 0 ]; then
+    echo "WARNING: Found ${N_CRITICAL} Critical CVEs for image $1 in ${CMD_LOGFILE}"
+    echo
+    egrep "SEVERITY|Critical" ${CMD_LOGFILE}
+    echo
+  fi
 }

--- a/.github/jobs/docker_build_metplus_images.sh
+++ b/.github/jobs/docker_build_metplus_images.sh
@@ -7,12 +7,6 @@ source "${GITHUB_WORKSPACE}"/.github/jobs/bash_functions.sh
 dockerhub_repo=dtcenter/metplus
 dockerhub_repo_analysis=dtcenter/metplus-analysis
 
-# check if tag is official or bugfix release -- no -betaN or -rcN suffix
-is_official=1
-if [[ "${SOURCE_BRANCH}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  is_official=0
-fi
-
 # remove v prefix
 metplus_version=${SOURCE_BRANCH:1}
 
@@ -29,7 +23,7 @@ echo "$met_tag"
 
 MET_DOCKER_REPO=met
 if [ "$met_tag" == "develop" ] || [[ "${met_tag}" =~ ^main_v[0-9]+\.[0-9]+ ]]; then
-    MET_DOCKER_REPO=met-dev
+  MET_DOCKER_REPO=met-dev
 fi
 
 # get METplus Analysis tool versions
@@ -58,12 +52,4 @@ if ! time_command docker build -t "$METPLUS_A_IMAGE_NAME" \
        -f "${GITHUB_WORKSPACE}"/internal/scripts/docker/Dockerfile.metplus-analysis \
        "${GITHUB_WORKSPACE}"; then
     exit 1
-fi
-
-# if official release, create X.Y-latest tag as well
-if [ "${is_official}" == 0 ]; then
-    LATEST_TAG=$(echo "$metplus_version" | cut -f1,2 -d'.')-latest
-    docker tag "${METPLUS_IMAGE_NAME}" "${dockerhub_repo}:${LATEST_TAG}"
-    docker tag "${METPLUS_A_IMAGE_NAME}" "${dockerhub_repo_analysis}:${LATEST_TAG}"
-    echo LATEST_TAG="${LATEST_TAG}" >> "$GITHUB_OUTPUT"
 fi

--- a/.github/jobs/docker_push_metplus_images.sh
+++ b/.github/jobs/docker_push_metplus_images.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # assumes SOURCE_BRANCH is set before calling script
-# assumes latest_tag will be set if pushing an official or bugfix release
 
 source "${GITHUB_WORKSPACE}"/.github/jobs/bash_functions.sh
 
@@ -18,8 +17,8 @@ METPLUS_A_IMAGE_NAME=${dockerhub_repo_analysis}:${metplus_version}
 
 # skip docker push if credentials are not set
 if [ -z ${DOCKER_USERNAME+x} ] || [ -z ${DOCKER_PASSWORD+x} ]; then
-    echo "DockerHub credentials not set. Skipping docker push"
-    exit 0
+  echo "DockerHub credentials not set. Skipping docker push"
+  exit 0
 fi
 
 echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
@@ -34,13 +33,24 @@ if ! time_command docker push "${METPLUS_A_IMAGE_NAME}"; then
   exit 1
 fi
 
-# only push X.Y-latest tag if official or bugfix release
+# only push X.Y-latest tag if requested for official or bugfix releases
 # shellcheck disable=SC2154
-if [ "${LATEST_TAG}" != "" ]; then
-    if ! time_command docker push "${dockerhub_repo}:${LATEST_TAG}"; then
-      exit 1
-    fi
-    if ! time_command docker push "${dockerhub_repo_analysis}:${LATEST_TAG}"; then
-      exit 1
-    fi
+if [[ "${UPDATE_LATEST}" == "true" && "${SOURCE_BRANCH}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  latest_version=$(echo ${metplus_version} | cut -f1,2 -d'.')-latest
+
+  # tag and push the METplus image
+  if ! time_command docker tag ${METPLUS_IMAGE_NAME} "${dockerhub_repo}:${latest_version}"; then
+    exit 1
+  fi
+  if ! time_command docker push "${dockerhub_repo}:${latest_version}"; then
+    exit 1
+  fi
+
+  # tag and push the METplus Analysis image
+  if ! time_command docker tag ${METPLUS_A_IMAGE_NAME} "${dockerhub_repo_analysis}:${latest_version}"; then
+    exit 1
+  fi
+  if ! time_command docker push "${dockerhub_repo_analysis}:${latest_version}"; then
+    exit 1
+  fi
 fi

--- a/.github/jobs/docker_scan_metplus_images.sh
+++ b/.github/jobs/docker_scan_metplus_images.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# assumes SOURCE_BRANCH is set before calling script
+
+source "${GITHUB_WORKSPACE}"/.github/jobs/bash_functions.sh
+
+# get names of images to push
+
+dockerhub_repo=dtcenter/metplus
+dockerhub_repo_analysis=dtcenter/metplus-analysis
+
+# remove v prefix
+metplus_version=${SOURCE_BRANCH:1}
+
+METPLUS_IMAGE_NAME=${dockerhub_repo}:${metplus_version}
+METPLUS_A_IMAGE_NAME=${dockerhub_repo_analysis}:${metplus_version}
+
+# Scan the images
+cve_scan_image ${METPLUS_IMAGE_NAME}
+cve_scan_image ${METPLUS_A_IMAGE_NAME}

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -10,7 +10,7 @@ on:
     inputs:
       release_version:
         description: 'Comma-separated list of versions to build, e.g. "v6.0.0","v6.1.0"'
-        default: '"v6.0.0"'
+        default: '"v6.1.0"'
         required: true
         type: string
       update_latest:
@@ -36,7 +36,7 @@ jobs:
         id: get-versions
         run: |
           if [[ ${{ github.event_name }} == 'schedule' ]]; then
-            version_list="\"v6.0.0\""
+            version_list="\"v6.0.0\",\"v6.1.0\""
             update_latest="true"
           elif [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
             version_list=${{ toJSON(inputs.release_version) }}

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -1,49 +1,119 @@
-name: Create Docker images for release
+name: Create Release Docker Images
 
 on:
+
   release:
     types:
       - published
+
   workflow_dispatch:
     inputs:
-      version:
-        description: 'vX.Y.Z version of METplus to rebuild, e.g. v6.0.0'
+      release_version:
+        description: 'Comma-separated list of versions to build, e.g. "v6.0.0","v6.1.0"'
+        default: '"v6.0.0"'
         required: true
+        type: string
+      update_latest:
+        description: 'For "vX.Y.Z" versions, update the corresponding "X.Y-latest" images.'
+        default: false
+        required: true
+        type: boolean
+
+  schedule:
+    - cron: "30 06 * * 0"
 
 jobs:
-  build_and_push:
-    name: Build and Push Images
+
+  define-matrix:
+    name: Define Matrix
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.get-versions.outputs.matrix }}
+      update_latest: ${{ steps.get-versions.outputs.update_latest }}
+
+    steps:
+      - name: Get versions to build 
+        id: get-versions
+        run: |
+          if [[ ${{ github.event_name }} == 'schedule' ]]; then
+            version_list="\"v6.0.0\""
+            update_latest="true"
+          elif [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
+            version_list=${{ toJSON(inputs.release_version) }}
+            update_latest=${{ toJSON(inputs.update_latest) }}
+          else
+            version_list=\"${{ toJSON(github.ref_name) }}\"
+            update_latest="true"
+          fi
+          echo "matrix={\"version\": [ ${version_list} ]}" >> $GITHUB_OUTPUT
+          echo "update_latest=${update_latest}" >> $GITHUB_OUTPUT
+ 
+  build_scan_and_push:
+    name: Build, Scan, and Push Images
+    runs-on: ubuntu-latest
+    needs: define-matrix
+    strategy:
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.version }}
+          path: ${{ matrix.version }}
+          sparse-checkout: internal/scripts/docker
+          sparse-checkout-cone-mode: false
+
       - uses: actions/checkout@v4
         with:
           ref: 'develop'
           path: 'develop'
           sparse-checkout: metplus/component_versions.py
           sparse-checkout-cone-mode: false
-      - name: Get and check tag name
-        id: get_tag_name
+
+      - name: Create directories to store output
         run: |
-          if [ ${{ github.event_name != 'workflow_dispatch' }} ]; then
-            SOURCE_BRANCH=${{ github.event.inputs.version }}
-          else
-            SOURCE_BRANCH=${GITHUB_REF#refs/tags/}
-          fi
-          if [[ ! "${SOURCE_BRANCH}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            echo "ERROR: Tag name (${SOURCE_BRANCH}) does not start with vX.Y.Z format"
-            exit 1
-          fi
-          echo SOURCE_BRANCH=${SOURCE_BRANCH} >> $GITHUB_OUTPUT
-      - name: Build metplus and metplus-analysis images
+          mkdir -p ${RUNNER_WORKSPACE}/logs
+
+      - name: Build Docker Images
         id: build_images
         run: .github/jobs/docker_build_metplus_images.sh
         env:
-          SOURCE_BRANCH: ${{ steps.get_tag_name.outputs.SOURCE_BRANCH }}
-      - name: Push metplus and metplus-analysis images
-        run: .github/jobs/docker_push_metplus_images.sh
+          SOURCE_BRANCH: ${{ matrix.version }}
+
+      - name: Install Syft
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+
+      - name: Install Grype
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+
+      - name: Scan Docker Images
+        run: |
+          .github/jobs/docker_scan_metplus_images.sh
         env:
-          SOURCE_BRANCH: ${{ steps.get_tag_name.outputs.SOURCE_BRANCH }}
-          LATEST_TAG: ${{ steps.build_images.outputs.LATEST_TAG }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          SOURCE_BRANCH: ${{ matrix.version }}
+
+      - name: Push Docker Images
+        run: |
+          .github/jobs/docker_push_metplus_images.sh
+        env:
+          SOURCE_BRANCH: ${{ matrix.version }}
+          UPDATE_LATEST: ${{ fromJSON(needs.define-matrix.outputs.update_latest) }}
+          DOCKER_USERNAME: 'dtcenter'
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Copy log files into logs directory
+        if: always()
+        run: |
+          cp ${GITHUB_WORKSPACE}/*.log ${RUNNER_WORKSPACE}/logs/
+
+      - name: Upload logs as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs_${{ matrix.version }}
+          path: ${{ runner.workspace }}/logs
+          if-no-files-found: ignore

--- a/docs/Contributors_Guide/continuous_integration.rst
+++ b/docs/Contributors_Guide/continuous_integration.rst
@@ -973,11 +973,11 @@ environments use this environment as a base.
 * Python 3.12.0
 * matplotlib 3.10.0
 * scipy 1.15.1
-* plotly 6.0.0
+* plotly 6.1.1
 * xarray 2025.1.2
 * netcdf4 1.7.2
 * pyyaml 6.0.2
-* python-kaleido 0.2.1
+* python-kaleido 1.0.0 
 * imageio 2.37.0
 * imutils 0.5.4
 * scikit-image 0.25.1

--- a/docs/Contributors_Guide/continuous_integration.rst
+++ b/docs/Contributors_Guide/continuous_integration.rst
@@ -977,7 +977,7 @@ environments use this environment as a base.
 * xarray 2025.1.2
 * netcdf4 1.7.2
 * pyyaml 6.0.2
-* python-kaleido 1.0.0 
+* python-kaleido 1.0.0
 * imageio 2.37.0
 * imutils 0.5.4
 * scikit-image 0.25.1

--- a/docs/Release_Guide/met_bugfix.rst
+++ b/docs/Release_Guide/met_bugfix.rst
@@ -10,6 +10,7 @@ Create a new vX.Y.Z bugfix release from the main_vX.Y branch.
 .. include:: release_steps/checkout_main_branch.rst
 .. include:: release_steps/create_release_feature_branch.rst
 .. include:: release_steps/met/update_version_bugfix.rst
+.. include:: release_steps/update_docker_image_workflow.rst
 .. include:: release_steps/update_release_notes_bugfix.rst
 .. include:: release_steps/merge_release_issue.rst
 .. include:: release_steps/create_release_on_github.rst

--- a/docs/Release_Guide/met_official.rst
+++ b/docs/Release_Guide/met_official.rst
@@ -10,6 +10,7 @@ Create a new vX.Y.Z official release from the develop branch.
 .. include:: release_steps/checkout_main_branch.rst
 .. include:: release_steps/create_release_feature_branch.rst
 .. include:: release_steps/met/update_version_official.rst
+.. include:: release_steps/update_docker_image_workflow.rst
 .. include:: release_steps/update_release_notes_official.rst
 .. include:: release_steps/update_upgrade_instructions.rst
 .. include:: release_steps/rotate_authorship.rst

--- a/docs/Release_Guide/metplus_bugfix.rst
+++ b/docs/Release_Guide/metplus_bugfix.rst
@@ -10,6 +10,7 @@ Create a new vX.Y.Z bugfix release from the main_vX.Y branch.
 .. include:: release_steps/checkout_main_branch.rst
 .. include:: release_steps/create_release_feature_branch.rst
 .. include:: release_steps/metplus/update_version_bugfix.rst
+.. include:: release_steps/update_docker_image_workflow.rst
 .. include:: release_steps/update_release_notes_bugfix.rst
 .. include:: release_steps/metplus/update_existing_builds_docker.rst
 .. include:: release_steps/merge_release_issue.rst

--- a/docs/Release_Guide/metplus_official.rst
+++ b/docs/Release_Guide/metplus_official.rst
@@ -10,6 +10,7 @@ Create a new vX.Y.Z official release from the develop branch.
 .. include:: release_steps/checkout_main_branch.rst
 .. include:: release_steps/create_release_feature_branch.rst
 .. include:: release_steps/metplus/update_version_official.rst
+.. include:: release_steps/update_docker_image_workflow.rst
 .. include:: release_steps/metplus/update_release_date.rst
 .. include:: release_steps/update_release_notes_official.rst
 .. include:: release_steps/update_upgrade_instructions.rst

--- a/docs/Release_Guide/metviewer_bugfix.rst
+++ b/docs/Release_Guide/metviewer_bugfix.rst
@@ -10,6 +10,7 @@ Create a new vX.Y.Z bugfix release from the main_vX.Y branch.
 .. include:: release_steps/checkout_main_branch.rst
 .. include:: release_steps/create_release_feature_branch.rst
 .. include:: release_steps/metviewer/update_version_bugfix.rst
+.. include:: release_steps/update_docker_image_workflow.rst
 .. include:: release_steps/update_release_notes_bugfix.rst
 .. include:: release_steps/merge_release_issue.rst
 .. include:: release_steps/create_release_on_github.rst

--- a/docs/Release_Guide/metviewer_official.rst
+++ b/docs/Release_Guide/metviewer_official.rst
@@ -10,6 +10,7 @@ Create a new vX.Y.Z official release from the develop branch.
 .. include:: release_steps/checkout_main_branch.rst
 .. include:: release_steps/create_release_feature_branch.rst
 .. include:: release_steps/metviewer/update_version_official.rst
+.. include:: release_steps/update_docker_image_workflow.rst
 .. include:: release_steps/update_release_notes_official.rst
 .. include:: release_steps/update_upgrade_instructions.rst
 .. include:: release_steps/rotate_authorship.rst

--- a/docs/Release_Guide/release_steps/update_docker_image_workflow.rst
+++ b/docs/Release_Guide/release_steps/update_docker_image_workflow.rst
@@ -1,0 +1,20 @@
+Update Docker Image Workflow
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Update the list of versions whose Docker images should be rebuilt on schedule.
+
+.. dropdown:: Instructions
+
+  * The **Create Release Docker Images** workflow is defined in '.github/workflows/release-docker-images.yml'.
+
+  * In the 'workflow_dispatch' section, consider updating the *default* 'release_version' to be built.
+
+  * In the 'define-matrix' job, update the 'version_list' for **schedule** events:
+
+    * Add the new vX.Y.Z version to the list of versions.
+
+    * For bugfix releases, remove the previous bugfix version, e.g. vX.Y.Z-1. 
+      Only the most recent 'vX.Y.Z' bugfix version for each 'vX.Y' release can
+      be listed to avoid ambiguity when updating 'X.Y-latest' tags on Docker Hub.
+
+    * For official releases, remove earlier versions only if their support has ended. 

--- a/internal/scripts/docker_env/scripts/metplotpy_env.sh
+++ b/internal/scripts/docker_env/scripts/metplotpy_env.sh
@@ -2,16 +2,19 @@
 
 ################################################################################
 # Environment: metplotpy.v6.1
-# Last Updated: 2025-02-05 (mccabe@ucar.edu)
-# Notes: Adds Python packages needed to run METplotpy and METcalcpy
+# Updated: 2025-07-16 (johnhg@ucar.edu)
+#   Increases plotly version from 6.0.0 to 6.1.1
+#   Increases kaleido version from 0.2.1 to 1.0.0
+# Updated: 2025-02-05 (mccabe@ucar.edu)
+#   Adds Python packages needed to run METplotpy and METcalcpy
 # Python Packages:
 #   matplotlib==3.10.0
 #   scipy==1.15.1
-#   plotly==6.0.0
+#   plotly==6.1.1
 #   xarray==2025.1.2
 #   netcdf4==1.7.2
 #   pyyaml==6.0.2
-#   python-kaleido==0.2.1
+#   python-kaleido==1.0.0
 #   imageio==2.37.0
 #   imutils==0.5.4
 #   scikit-image==0.25.1
@@ -36,11 +39,11 @@ conda create -y --clone ${BASE_ENV} --name ${ENV_NAME}
 mamba install -y --name ${ENV_NAME} -c conda-forge \
   matplotlib==3.10.0 \
   scipy==1.15.1 \
-  plotly==6.0.0 \
+  plotly==6.1.1 \
   xarray==2025.1.2 \
   netcdf4==1.7.2 \
   pyyaml==6.0.2 \
-  python-kaleido==0.2.1 \
+  python-kaleido==1.0.0 \
   imageio==2.37.0 \
   imutils==0.5.4 \
   scikit-image==0.25.1 \

--- a/internal/scripts/installation/metplus_components_v6.1_py3.12.sh
+++ b/internal/scripts/installation/metplus_components_v6.1_py3.12.sh
@@ -7,12 +7,12 @@ ${MINICONDA_PATH}/bin/conda create -y --name ${ENV_NAME} -c conda-forge python=3
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge python-dateutil==2.9.0.post0
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge matplotlib==3.10.3
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge scipy==1.15.1
-${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge plotly==6.0.0
+${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge plotly==6.1.1
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge xarray==2025.1.2
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge netcdf4==1.7.2
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge pyyaml==6.0.2
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge statsmodels
-${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge python-kaleido==0.2.1
+${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge python-kaleido==1.0.0
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge imageio==2.37.0
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge imutils==0.5.4
 ${MINICONDA_PATH}/bin/conda install -y --name ${ENV_NAME} -c conda-forge scikit-image==0.25.1


### PR DESCRIPTION
These are the same changes as those for PR #3055 but for the `main_v6.1` branch instead. Please note that the versions listed in the `release-docker-images.yml` workflow are updated to include version 6.1.

Please review this PR at the same time as #3055.