### PR TITLE
Update METplus-6.1 version of MET to v12.1.1

### DIFF
--- a/metplus/component_versions.py
+++ b/metplus/component_versions.py
@@ -25,7 +25,7 @@ VERSION_LOOKUP = {
     },
     '6.1': {
         'metplus': '6.1.0',
-        'met': '12.1.0',
+        'met': '12.1.1',
         'metplotpy': '3.1.0',
         'metcalcpy': '3.1.0',
         'metdataio': '3.1.0',


### PR DESCRIPTION
## Pull Request Testing ##

Update the METplus-6.1 coordinated release version lookup table for MET to v12.1.1 after the bugfix release.