### PR TITLE
Fix diff_util.py to check for differences in the extent of missing data

### DIFF
--- a/internal/tests/pytests/conftest.py
+++ b/internal/tests/pytests/conftest.py
@@ -227,7 +227,7 @@ def make_nc(tmp_path, lon, lat, z, data, variable='Temp', file_name='fake.nc'):
         longitude = rootgrp.createVariable("Longitude", "f4", "lon")
         latitude = rootgrp.createVariable("Latitude", "f4", "lat")
         levels = rootgrp.createVariable("Levels", "i4", "z")
-        temp = rootgrp.createVariable(variable, "f4", ("time", "lon", "lat", "z"))
+        temp = rootgrp.createVariable(variable, "f4", ("time", "lon", "lat", "z"), fill_value=-9999)
         rootgrp.createVariable("Time", "i4", "time")
 
         longitude[:] = lon

--- a/internal/tests/pytests/util/diff_util/test_diff_util.py
+++ b/internal/tests/pytests/util/diff_util/test_diff_util.py
@@ -347,6 +347,23 @@ def test_get_file_type_extensions():
             False,
             ["Variable Temp contains NaN. Comparing each value"],
         ),
+        # Contains difference in masked count
+        (
+            [
+                DEFAULT_NC[0],
+                DEFAULT_NC[1],
+                DEFAULT_NC[2],
+                [
+                    [[1, 2], [3, 4], [5, 6]],
+                    [[2, 3], [4, 5], [6, 7]],
+                    [[30, 31], [33, 32], [34, -9999]],
+                ],
+                DEFAULT_NC[4],
+            ],
+            None,
+            False,
+            ["Field Temp has differing number of missing data values"],
+        ),
         # Field doesn't exist
         (
             [

--- a/metplus/util/diff_util.py
+++ b/metplus/util/diff_util.py
@@ -10,6 +10,7 @@ from math import log10, isclose
 from PIL import Image, ImageChops
 from pandas import isnull
 from numpy.ma import is_masked
+from numpy.ma import count_masked
 
 # file extensions for supported image file types
 IMAGE_EXTENSIONS = [
@@ -784,6 +785,13 @@ def _nc_fields_are_equal(field, nc_a, nc_b, debug=False):
 
     values_a = var_a[:]
     values_b = var_b[:]
+
+    # check for same amount of masked data
+    if count_masked(values_a) != count_masked(values_b):
+        print(f"ERROR: Field {field} has differing number of missing data values")
+        return False
+
+    # compute diffs
     try:
         values_diff = values_a - values_b
     except TypeError:


### PR DESCRIPTION
## Pull Request Testing ##

This MET [testing workflow run](https://github.com/dtcenter/MET/actions/runs/20315789083) failed to flag differences in a NetCDF file created by Point2Grid when it should have.

This proposed tweak to `diff_util.py` checks for a differing number of masked points in the files being compared. 

- [x] Describe testing already performed for these changes:</br>
Used the data in [test_files.tar.gz](https://github.com/user-attachments/files/24222918/test_files.tar.gz) to confirm that these diffs are now flagged:
```
>  metplus/util/diff_util.py one two
::group::Full diff results:

# # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

COMPARING point2grid_GOES_16_AOD_TO_G212.nc
file_A: one/point2grid_GOES_16_AOD_TO_G212.nc
file_B: two/point2grid_GOES_16_AOD_TO_G212.nc

Using default rounding precision 6
Comparing NetCDF
ERROR: Field AOD has differing number of missing data values
::endgroup::


Number of files compared = 1


**************************************************
Summary:

ERROR: Differences were found with 1 files

NetCDF diff
  A:one/point2grid_GOES_16_AOD_TO_G212.nc
  B:two/point2grid_GOES_16_AOD_TO_G212.nc

Finished comparing directories
**************************************************
```
However, I do note that the legacy MET diffing logic in R also DOES NOT correctly flag this difference:
```
> bin/comp_nc.sh one/point2grid_GOES_16_AOD_TO_G212.nc two/point2grid_GOES_16_AOD_TO_G212.nc 
passed numerical var AOD 
passed numerical var t 
```
- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
Confirm that you agree a change to the number of grid points with bad data values really should count as a difference. Test as you see fit.

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[No]**
None needed

- [x] Do these changes include sufficient testing updates? **[Yes]**
I figured it out ;)
I updated `make_nc` to add a fill_value attribute for the `temp` variable. Then I added a test to confirm that a differing amount of missing data does trigger the new logic and log:
`Field Temp has differing number of missing data values`

- [x] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] Do these changes introduce new SonarQube findings? **[No]**</br>
If **yes**, please describe:

- [x] Please complete this pull request review by **[Thurs 12/18/25]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [ ] Add any new Python packages to the [METplus Components Python Requirements](https://metplus.readthedocs.io/en/develop/Users_Guide/appendixA.html#metplus-components-python-packages) table.
- [ ] For any new datasets, an entry to the [METplus Verification Datasets Guide](https://metplus.readthedocs.io/en/latest/Verification_Datasets/index.html).
- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR definition above.
- [ ] Ensure the PR title matches the feature or bugfix branch name.
- [ ] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **Coordinated METplus-X.Y Support** project for bugfix releases or **METplus-Wrappers-X.Y.Z Development** project for official releases
- [ ] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
