### PR TITLE
Feature #3220 met_version_diff

### DIFF
--- a/metplus/util/diff_util.py
+++ b/metplus/util/diff_util.py
@@ -867,8 +867,6 @@ def _nc_fields_are_equal(field, nc_a, nc_b):
         return False, f"ERROR: Field {field} not found"
 
     msg = f"Field: {field}\nVar_A:{var_a}\nVar_B:{var_b}"
-    if len(var_a) > 0:
-      msg += f"\nInstance type: {type(var_a[0])}"
 
     values_a = var_a[:]
     values_b = var_b[:]

--- a/metplus/util/diff_util.py
+++ b/metplus/util/diff_util.py
@@ -671,9 +671,10 @@ def compare_txt_files(filepath_a, filepath_b, dir_a=None, dir_b=None):
     elif not len(lines_a):
         return False, f"Empty file: {filepath_a}\nNot empty: {filepath_b}"
 
-    # check if the files are "file list" files
-    # remove file_list first line for comparison
-    _handle_file_list_files(lines_a, lines_b)
+    # handle "file list" files
+    lines_a, lines_b = _handle_file_list_files(os.path.basename(filepath_a),
+                                               os.path.basename(filepath_b),
+                                               lines_a, lines_b)
 
     # check if file is a METplus data file
     # - MET stat header lines starting with 'VERSION'
@@ -718,11 +719,12 @@ def compare_txt_files(filepath_a, filepath_b, dir_a=None, dir_b=None):
                            is_stat_file=is_stat_file, header=header_a)
 
 
-def _handle_file_list_files(lines_a, lines_b):
-    """!Check if the files are "file list" files.
-    Remove the first line that contains the string "file_list" for comparison.
+def _handle_file_list_files(filename_a, filename_b, lines_a, lines_b):
+    """!Check the file names and contents for "file_list".
     """
     is_file_list = False
+
+    # remove "file_list" from the first line for comparison
     if lines_a[0] == 'file_list':
         is_file_list = True
         lines_a.pop(0)
@@ -730,10 +732,17 @@ def _handle_file_list_files(lines_a, lines_b):
         is_file_list = True
         lines_b.pop(0)
 
+    # check for "file_list" in the filename
+    if filename_a.find('file_list') or filename_b.find('file_list'):
+       is_file_list = True
+
+    # replace "MET-*/" with "MET/" to ignore path differences
     if is_file_list:
         print("Comparing file list file")
+        lines_a = [re.sub("MET-[a-zA-Z-]*/", "MET/", item) for item in lines_a]
+        lines_b = [re.sub("MET-[a-zA-Z-]*/", "MET/", item) for item in lines_b]
 
-    return is_file_list
+    return lines_a, lines_b
 
 
 def diff_text_lines(lines_a, lines_b, dir_a=None, dir_b=None,

--- a/metplus/util/diff_util.py
+++ b/metplus/util/diff_util.py
@@ -866,7 +866,9 @@ def _nc_fields_are_equal(field, nc_a, nc_b):
     except KeyError:
         return False, f"ERROR: Field {field} not found"
 
-    msg = f"Field: {field}\nVar_A:{var_a}\nVar_B:{var_b}\nInstance type: {type(var_a[0])}"
+    msg = f"Field: {field}\nVar_A:{var_a}\nVar_B:{var_b}"
+    if len(var_a) > 0:
+      msg += f"\nInstance type: {type(var_a[0])}"
 
     values_a = var_a[:]
     values_b = var_b[:]

--- a/metplus/util/diff_util.py
+++ b/metplus/util/diff_util.py
@@ -739,8 +739,8 @@ def _handle_file_list_files(filename_a, filename_b, lines_a, lines_b):
     # replace "MET-*/" with "MET/" to ignore path differences
     if is_file_list:
         print("Comparing file list file")
-        lines_a = [re.sub("MET-[a-zA-Z-]*/", "MET/", item) for item in lines_a]
-        lines_b = [re.sub("MET-[a-zA-Z-]*/", "MET/", item) for item in lines_b]
+        lines_a = [re.sub(r"/MET-[^/]*/", r"/MET/", item) for item in lines_a]
+        lines_b = [re.sub(r"/MET-[^/]*/", r"/MET/", item) for item in lines_b]
 
     return lines_a, lines_b
 


### PR DESCRIPTION
## Pull Request Testing ##

This PR proposes the following changes to the METplus diff logic:
- Update `_nc_fields_are_equal()` to remove unneeded reference to `var_a[0]` in a log message which causes an exception for 1D NetCDF variables.
- Update `_handle_file_list_files()` logic to also pass the filenames as input. Also consider them to be file lists if the file names contain `file_list`. For file lists, replace instances of `MET-*/` with `MET/` to ignore unimportant diffs in the path to MET. Update that function to return the sanitized version of `lines_a` and `lines_b` so they can be used as input to the diffing logic below.

- [x] Describe testing already performed for these changes:</br>
Note that the diffs failed for the MET Nightly Build on seneca in `/d1/projects/MET/MET_regression/develop/NB20260206`. 
On seneca, I reran the diff using the following commands:
```
cd /d1/personal/johnhg/METplus/development/METplus-7.0.0/beta2/METplus-feature_3220_met_version_diff
ln -sf /d1/projects/MET/MET_regression/develop/NB20260206 .
export METPLUS_DIR=.
NB20260206/MET-develop/internal/test_unit/python/comp_dir.py \
NB20260206/MET-develop-ref/test_output \
NB20260206/MET-develop/test_output >& comp_dir_feature_3220.log
```
And I confirmed that differences are no longer flagged, even with the version difference where `MET-develop-ref` has `V12.2.0` and `MET-develop` has `V13.0.0`.
```
Number of files compared = 1251
Number of files skipped = 19
SUCCESS: No differences found in any files
```

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
Confirm that all the GHA tests pass.

- [ ] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes or No]**

- [ ] Do these changes include sufficient testing updates? **[Yes or No]**

- [ ] Will this PR result in changes to the test suite? **[Yes or No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [ ] Do these changes introduce new SonarQube findings? **[Yes or No]**</br>
If **yes**, please describe:

- [ ] Please complete this pull request review by **[Fill in date]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [ ] Add any new Python packages to the [METplus Components Python Requirements](https://metplus.readthedocs.io/en/develop/Users_Guide/appendixA.html#metplus-components-python-packages) table.
- [ ] For any new datasets, an entry to the [METplus Verification Datasets Guide](https://metplus.readthedocs.io/en/latest/Verification_Datasets/index.html).
- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR definition above.
- [ ] Ensure the PR title matches the feature or bugfix branch name.
- [ ] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **Coordinated METplus-X.Y Support** project for bugfix releases or **METplus-Wrappers-X.Y.Z Development** project for official releases
- [ ] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
